### PR TITLE
Add Unit Tests to `legacy/src/service.rs`

### DIFF
--- a/crates/legacy/src/lib.rs
+++ b/crates/legacy/src/lib.rs
@@ -26,20 +26,46 @@ use hotshot_types::{
     traits::node_implementation::NodeType, utils::BuilderCommitment, vid::VidCommitment,
 };
 
+/// WaitAndKeep is a helper enum that allows for the lazy polling of a single
+/// value from an unbound receiver.
 #[derive(Debug)]
 pub enum WaitAndKeep<T> {
     Keep(T),
     Wait(UnboundedReceiver<T>),
 }
 
+#[derive(Debug)]
+pub(crate) enum WaitAndKeepGetError {
+    FailedToResolvedVidCommitmentFromChannel,
+}
+
+impl From<WaitAndKeepGetError> for BuildError {
+    fn from(e: WaitAndKeepGetError) -> Self {
+        match e {
+            WaitAndKeepGetError::FailedToResolvedVidCommitmentFromChannel => BuildError::Error {
+                message: "failed to resolve VidCommitment from channel".to_string(),
+            },
+        }
+    }
+}
+
 impl<T: Clone> WaitAndKeep<T> {
-    pub async fn get(&mut self) -> Result<T, BuildError> {
+    /// get will return a clone of the value that is already stored within the
+    /// value of WaitAndKeep::Keep if the value is already resolved.  Otherwise
+    /// it will poll the next value from the channel and replace the locally
+    /// stored WaitAndKeep::Wait with the resolved value as a WaitAndKeep::Keep.
+    ///
+    /// Note: This pattern seems very similar to a Future, and ultimately
+    /// returns a future. It's not clear why this needs to be implemented
+    /// in such a way and not just implemented as a boxed future.
+    pub(crate) async fn get(&mut self) -> Result<T, WaitAndKeepGetError> {
         match self {
             WaitAndKeep::Keep(t) => Ok(t.clone()),
             WaitAndKeep::Wait(fut) => {
-                let got = fut.recv().await.map_err(|_| BuildError::Error {
-                    message: "failed to resolve VidCommitment from channel".to_string(),
-                });
+                let got = fut
+                    .recv()
+                    .await
+                    .map_err(|_| WaitAndKeepGetError::FailedToResolvedVidCommitmentFromChannel);
                 if let Ok(got) = &got {
                     let mut replace = WaitAndKeep::Keep(got.clone());
                     core::mem::swap(self, &mut replace);

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -3285,7 +3285,7 @@ mod test {
     }
 
     /// This test checks that call to `available_blocks_implementation` returns
-    /// a successful response when the function is called before after are
+    /// a successful response when the function is called after blocks are
     /// made available.
     #[async_std::test]
     async fn test_get_available_blocks_requested_after_blocks_available() {

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -717,7 +717,7 @@ impl<Types: NodeType> ProxyGlobalState<Types> {
             tracing::info!("Done Trying sending vid trigger info for {block_id}",);
 
             // sign over the builder commitment, as the proposer can computer it based on provide block_payload
-            // and the met data data
+            // and the metadata
             let response_block_hash = block_payload.builder_commitment(&metadata);
             let signature_over_builder_commitment =
                 <Types as NodeType>::BuilderSignatureKey::sign_builder_message(

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -2630,6 +2630,12 @@ mod test {
         }
 
         assert_eq!(
+            state.spawned_builder_states.len(),
+            11,
+            "The spawned_builder_states should have the expected number of entries",
+        );
+
+        assert_eq!(
             state.remove_handles(ViewNumber::new(100)),
             ViewNumber::new(10),
             "It should only be able to prune up to what has been stored"

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -201,8 +201,16 @@ impl<Types: NodeType> GlobalState<Types> {
         request_sender: BroadcastSender<MessageType<Types>>,
     ) {
         // register the builder state
-        self.spawned_builder_states
+        let previous_value = self
+            .spawned_builder_states
             .insert(parent_id.clone(), request_sender);
+
+        if let Some(previous_value) = previous_value {
+            tracing::warn!(
+                "builder {parent_id} overwrote previous spawned_builder_state entry: {:?}",
+                previous_value
+            );
+        }
 
         // keep track of the max view number
         if parent_id.view > self.highest_view_num_builder_id.view {

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -84,51 +84,6 @@ pub struct BlockInfo<Types: NodeType> {
     pub truncated: bool,
 }
 
-// It holds the information for the proposed block
-
-/// [ProposedBlockId] contains information relating to what has been proposed
-/// for a Block.
-///
-/// This is only referenced within [BuilderStatesInfo] and does not seem to be
-/// utilized.
-///
-/// TODO: look into whether it needs to stick around or not.
-#[derive(Debug)]
-pub struct ProposedBlockId<Types: NodeType> {
-    pub parent_commitment: VidCommitment,
-    pub payload_commitment: BuilderCommitment,
-    pub parent_view: Types::Time,
-}
-
-impl<Types: NodeType> ProposedBlockId<Types> {
-    pub fn new(
-        parent_commitment: VidCommitment,
-        payload_commitment: BuilderCommitment,
-        parent_view: Types::Time,
-    ) -> Self {
-        ProposedBlockId {
-            parent_commitment,
-            payload_commitment,
-            parent_view,
-        }
-    }
-}
-
-/// [BuilderStatesInfo] holds information concerning [VidCommitment]s and
-/// [ProposedBlockId]s.
-///
-/// It does not seem to be utilized
-///
-/// TODO: look into whether it needs to stick around or not
-#[derive(Debug, Derivative)]
-#[derivative(Default(bound = ""))]
-pub struct BuilderStatesInfo<Types: NodeType> {
-    // list of all the builder states spawned for a view
-    pub vid_commitments: Vec<VidCommitment>,
-    // list of all the proposed blocks for a view
-    pub block_ids: Vec<ProposedBlockId<Types>>,
-}
-
 /// [ReceivedTransaction] represents receipt information concerning a received
 /// [NodeType::Transaction].
 #[derive(Debug)]

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -47,7 +47,6 @@ use async_compatibility_layer::{
 use async_lock::RwLock;
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
-use derivative::Derivative;
 use futures::stream::StreamExt;
 use futures::{future::BoxFuture, Stream};
 use hotshot_events_service::{events::Error as EventStreamError, events_source::StartupInfo};
@@ -1727,7 +1726,8 @@ impl<Types: NodeType> Iterator for HandleReceivedTxns<Types> {
         // to encoded length is enough, because we only use this value to estimate
         // our limitations on computing the VID in time.
         let len = bincode::serialized_size(&tx).unwrap_or_default();
-        if len > self.max_txn_len {
+        let max_txn_len = self.max_txn_len;
+        if len > max_txn_len {
             tracing::warn!(%commit, %len, %max_txn_len, "Transaction too big");
             return Some(Err(HandleReceivedTxnsError::TransactionTooBig {
                 estimated_length: len,

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -2647,17 +2647,6 @@ mod test {
             "The spawned_builder_states should only have a single entry in it"
         );
 
-        for i in 0..10 {
-            let builder_state_id = BuilderStateId {
-                parent_commitment: vid_commitment(&[i], 4),
-                view: ViewNumber::new(i as u64),
-            };
-            assert!(
-                !state.spawned_builder_states.contains_key(&builder_state_id),
-                "the spawned builder states should not contain the builder state id, {builder_state_id}"
-            );
-        }
-
         let builder_state_id = BuilderStateId {
             parent_commitment: vid_commitment(&[10], 4),
             view: ViewNumber::new(10),

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -4619,7 +4619,7 @@ mod test {
     /// before attempting to send any transactions through the broadcast channel
     /// sender.
     #[async_std::test]
-    async fn test_handle_received_txns_error_something() {
+    async fn test_handle_received_txns_error_internal() {
         let tx_sender = {
             let (tx_sender, _) = async_broadcast::broadcast(10);
             tx_sender

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -2911,7 +2911,7 @@ mod test {
     /// This test checks that the error `AvailableBlocksError::NoBlocksAvailable`
     /// is returned when no blocks are available.
     ///
-    /// To Trigger this condition, we simply submit a request to the
+    /// To trigger this condition, we simply submit a request to the
     /// implementation of get_available_blocks, and we do not provide any
     /// information for the block view number requested.  As a result, the
     /// implementation will ultimately timeout, and return an error that

--- a/crates/legacy/src/service.rs
+++ b/crates/legacy/src/service.rs
@@ -264,10 +264,10 @@ impl<Types: NodeType> GlobalState<Types> {
     /// Beyond that, the state prefers to drop all `spawned_builder_states`
     /// preceding the derived cutoff view.
     ///
-    /// In addition, for tracking purposes, the `last_garbage_collected_view_num`
-    /// is updated to the target cutoff view number for tracking purposes.  The
-    /// value returned is the cutoff view number such that the returned value
-    /// indicates the point before which everything was cleaned up.
+    /// In addition the `last_garbage_collected_view_num` is updated to the
+    /// target cutoff view number for tracking purposes.  The value returned
+    /// is the cutoff view number such that the returned value indicates the
+    /// point before which everything was cleaned up.
     pub fn remove_handles(&mut self, on_decide_view: Types::Time) -> Types::Time {
         // remove everything from the spawned builder states when view_num <= on_decide_view;
         // if we don't have a highest view > decide, use highest view as cutoff.

--- a/crates/legacy/src/testing/basic_test.rs
+++ b/crates/legacy/src/testing/basic_test.rs
@@ -394,7 +394,7 @@ mod tests {
             arc_rwlock_global_state
                 .read_arc()
                 .await
-                .get_channel_for_matching_builder_or_highest_view_buider(&req_msg.1)
+                .get_channel_for_matching_builder_or_highest_view_builder(&req_msg.1)
                 .expect("Failed to get channel for matching builder or highest view builder")
                 .broadcast(req_msg.2.clone())
                 .await


### PR DESCRIPTION
<!-- Closes #<ISSUE_NUMBER> -->
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Adds unit tests to the various functions and methods contained with the `service.rs` file of the `legacy` crate, formely known as the `hotshot-builder-core` crate.  These tests serve as test cases that assert current behavior, and attempt to draw attention to potential edge case behavior that can lead to confusion in the future.

These unit tests just assert that the currently coded behavior is the expected behavior, without knowing whether or not this is actually the intended case or not.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
Make any assumptions as whether the current implemented behavior is correct, or if they consider their edge cases correctly.

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->
- `test_global_state_register_builder_state_same_builder_state_id`

  This test asserts that submitting the same `BuilderStateId` to `register_builder_state` **SHOULD** result in the replacement of the previously stored Request Sender, and the previous one will be dropped.

- `test_global_state_update_global_state_replacement`

  This test asserts that a subsequent call to `update_global_state` with the same `BuilderStateId` **SHOULD NOT** replace the data currently stored in the `blocks` LRU, and **SHOULD** replace the data stored within `builder_state_to_last_built_block`.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
