### PR TITLE
Update `GlobalState` field

### DIFF
--- a/crates/legacy/src/testing/basic_test.rs
+++ b/crates/legacy/src/testing/basic_test.rs
@@ -38,7 +38,7 @@ mod tests {
     };
 
     use crate::builder_state::{
-        BuiltFromProposedBlock, DaProposalMessage, DecideMessage, QCMessage, RequestMessage,
+        DaProposalMessage, DecideMessage, ParentBlockReferences, QCMessage, RequestMessage,
         TransactionSource,
     };
     use crate::service::{handle_received_txns, GlobalState, ReceivedTransaction};
@@ -356,14 +356,14 @@ mod tests {
         let arc_rwlock_global_state = Arc::new(RwLock::new(global_state));
         let arc_rwlock_global_state_clone = arc_rwlock_global_state.clone();
         let handle = async_spawn(async move {
-            let built_from_info = BuiltFromProposedBlock {
+            let parent_block_references = ParentBlockReferences {
                 view_number: ViewNumber::new(0),
                 vid_commitment: vid_commitment(&[], 8),
                 leaf_commit: Commitment::<Leaf<TestTypes>>::default_commitment_no_preimage(),
                 builder_commitment: BuilderCommitment::from_bytes([]),
             };
             let builder_state = BuilderState::<TestTypes>::new(
-                built_from_info,
+                parent_block_references,
                 decide_receiver,
                 da_receiver,
                 qc_receiver,

--- a/crates/marketplace/src/builder_state.rs
+++ b/crates/marketplace/src/builder_state.rs
@@ -248,9 +248,12 @@ async fn best_builder_states_to_extend<TYPES: NodeType>(
     let existing_states: HashSet<_> = global_state_read_lock
         .spawned_builder_states
         .iter()
-        .filter(|(_, (leaf_commit, _))| match leaf_commit {
+        .filter(|(builder_state_id, (leaf_commit, _))| match leaf_commit {
             None => false,
-            Some(leaf_commit) => *leaf_commit == justify_qc.data.leaf_commit,
+            Some(leaf_commit) => {
+                *leaf_commit == justify_qc.data.leaf_commit
+                    && builder_state_id.parent_view == justify_qc.view_number
+            }
         })
         .map(|(builder_state_id, _)| builder_state_id.clone())
         .collect();

--- a/crates/marketplace/src/builder_state.rs
+++ b/crates/marketplace/src/builder_state.rs
@@ -13,7 +13,7 @@ use committable::{Commitment, Committable};
 
 use crate::{
     service::{BroadcastReceivers, GlobalState, ReceivedTransaction},
-    utils::{BlockId, BuilderStateId, BuiltFromProposedBlock, RotatingSet},
+    utils::{BlockId, BuilderStateId, ParentBlockReferences, RotatingSet},
 };
 use async_broadcast::broadcast;
 use async_broadcast::Receiver as BroadcastReceiver;
@@ -113,8 +113,8 @@ pub struct BuilderState<TYPES: NodeType> {
     pub quorum_proposal_payload_commit_to_quorum_proposal:
         HashMap<(BuilderCommitment, TYPES::Time), Arc<Proposal<TYPES, QuorumProposal<TYPES>>>>,
 
-    /// the spawned from info for a builder state
-    pub built_from_proposed_block: BuiltFromProposedBlock<TYPES>,
+    /// Spawned-from references to the parent block.
+    pub parent_block_references: ParentBlockReferences<TYPES>,
 
     // Channel Receivers for the HotShot events, Tx_receiver could also receive the external transactions
     /// decide receiver
@@ -248,15 +248,10 @@ async fn best_builder_states_to_extend<TYPES: NodeType>(
     let existing_states: HashSet<_> = global_state_read_lock
         .spawned_builder_states
         .iter()
-        .filter(
-            |(_, (built_from_proposed_block, _))| match built_from_proposed_block {
-                None => false,
-                Some(built_from_proposed_block) => {
-                    built_from_proposed_block.leaf_commit == justify_qc.data.leaf_commit
-                        && built_from_proposed_block.view_number == justify_qc.view_number
-                }
-            },
-        )
+        .filter(|(_, (leaf_commit, _))| match leaf_commit {
+            None => false,
+            Some(leaf_commit) => *leaf_commit == justify_qc.data.leaf_commit,
+        })
         .map(|(builder_state_id, _)| builder_state_id.clone())
         .collect();
 
@@ -333,8 +328,8 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
 
         tracing::debug!(
             "{}@{} thinks these are the best builder states to extend from: {:?} for proposal {}@{}",
-            self.built_from_proposed_block.vid_commitment,
-            self.built_from_proposed_block.view_number.u64(),
+            self.parent_block_references.vid_commitment,
+            self.parent_block_references.view_number.u64(),
             best_builder_states_to_extend
                 .iter()
                 .map(|builder_state_id| format!(
@@ -350,14 +345,14 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         // We are a best fit if we are contained within the returned set of
         // best [BuilderState]s to extend from.
         best_builder_states_to_extend.contains(&BuilderStateId {
-            parent_commitment: self.built_from_proposed_block.vid_commitment,
-            parent_view: self.built_from_proposed_block.view_number,
+            parent_commitment: self.parent_block_references.vid_commitment,
+            parent_view: self.parent_block_references.view_number,
         })
     }
 
     /// processing the DA proposal
     #[tracing::instrument(skip_all, name = "process da proposal",
-                                    fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
+                                    fields(builder_parent_block_references = %self.parent_block_references))]
     async fn process_da_proposal(&mut self, da_msg: Arc<DaProposalMessage<TYPES>>) {
         tracing::debug!(
             "Builder Received DA message for view {:?}",
@@ -413,7 +408,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
     /// processing the quorum proposal
     //#[tracing::instrument(skip_all, name = "Process Quorum Proposal")]
     #[tracing::instrument(skip_all, name = "process quorum proposal",
-                                    fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
+                                    fields(builder_parent_block_references = %self.parent_block_references))]
     async fn process_quorum_proposal(&mut self, qc_msg: QuorumProposalMessage<TYPES>) {
         tracing::debug!(
             "Builder Received QC Message for view {:?}",
@@ -488,7 +483,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         {
             tracing::debug!(
                 "{} is not the best fit for forking, {}@{}, so ignoring the QC proposal, and leaving it to another BuilderState",
-                self.built_from_proposed_block,
+                self.parent_block_references,
                 quorum_proposal.data.block_header.payload_commitment(),
                 quorum_proposal.data.view_number.u64(),
             );
@@ -499,7 +494,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
 
         tracing::debug!(
             "extending BuilderState with a clone from {} with new proposal {}@{}",
-            self.built_from_proposed_block,
+            self.parent_block_references,
             quorum_proposal.data.block_header.payload_commitment(),
             quorum_proposal.data.view_number.u64()
         );
@@ -512,9 +507,9 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
 
     /// processing the decide event
     #[tracing::instrument(skip_all, name = "process decide event",
-                                   fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
+                                   fields(builder_parent_block_references = %self.parent_block_references))]
     async fn process_decide_event(&mut self, decide_msg: DecideMessage<TYPES>) -> Option<Status> {
-        // Exit out all the builder states if their built_from_proposed_block.view_number is less than the latest_decide_view_number
+        // Exit out all the builder states if their parent_block_references.view_number is less than the latest_decide_view_number
         // The only exception is that we want to keep the highest view number builder state active to ensure that
         // we have a builder state to handle the incoming DA and QC proposals
         let decide_view_number = decide_msg.latest_decide_view_number;
@@ -524,11 +519,11 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             .write_arc()
             .await
             .remove_handles(decide_view_number);
-        if self.built_from_proposed_block.view_number < retained_view_cutoff {
+        if self.parent_block_references.view_number < retained_view_cutoff {
             tracing::info!(
                 "Decide@{:?}; Task@{:?} exiting; views < {:?} being reclaimed",
                 decide_view_number.u64(),
-                self.built_from_proposed_block.view_number.u64(),
+                self.parent_block_references.view_number.u64(),
                 retained_view_cutoff.u64(),
             );
             return Some(Status::ShouldExit);
@@ -536,7 +531,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         tracing::info!(
             "Decide@{:?}; Task@{:?} not exiting; views >= {:?} being retained",
             decide_view_number.u64(),
-            self.built_from_proposed_block.view_number.u64(),
+            self.parent_block_references.view_number.u64(),
             retained_view_cutoff.u64(),
         );
 
@@ -545,7 +540,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
 
     // spawn a clone of the builder state
     #[tracing::instrument(skip_all, name = "spawn_clone",
-                                    fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
+                                    fields(builder_parent_block_references = %self.parent_block_references))]
     async fn spawn_clone(
         mut self,
         da_proposal_info: Arc<DaProposalMessage<TYPES>>,
@@ -554,10 +549,10 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
     ) {
         let leaf = Leaf::from_quorum_proposal(&quorum_proposal.data);
 
-        // We replace our built_from_proposed_block with information from the
+        // We replace our parent_block_references with information from the
         // quorum proposal.  This is identifying the block that this specific
         // instance of [BuilderState] is attempting to build for.
-        self.built_from_proposed_block = BuiltFromProposedBlock {
+        self.parent_block_references = ParentBlockReferences {
             view_number: quorum_proposal.data.view_number,
             vid_commitment: quorum_proposal.data.block_header.payload_commitment(),
             leaf_commit: leaf.commit(),
@@ -565,8 +560,8 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         };
 
         let builder_state_id = BuilderStateId {
-            parent_commitment: self.built_from_proposed_block.vid_commitment,
-            parent_view: self.built_from_proposed_block.view_number,
+            parent_commitment: self.parent_block_references.vid_commitment,
+            parent_view: self.parent_block_references.view_number,
         };
 
         {
@@ -600,7 +595,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         // that it can be looked up via the [BuilderStateId] in the future.
         self.global_state.write_arc().await.register_builder_state(
             builder_state_id,
-            self.built_from_proposed_block.clone(),
+            self.parent_block_references.clone(),
             req_sender,
         );
 
@@ -609,7 +604,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
 
     // build a block
     #[tracing::instrument(skip_all, name = "build block",
-                                    fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
+                                    fields(builder_parent_block_references = %self.parent_block_references))]
     async fn build_block(
         &mut self,
         state_id: BuilderStateId<TYPES>,
@@ -650,14 +645,14 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
 
             tracing::info!(
                 "Builder view num {:?}, building block with {:?} txns, with builder hash {:?}",
-                self.built_from_proposed_block.view_number,
+                self.parent_block_references.view_number,
                 txn_count,
                 builder_hash
             );
 
             Some(BuildBlockInfo {
                 id: BlockId {
-                    view: self.built_from_proposed_block.view_number,
+                    view: self.parent_block_references.view_number,
                     hash: builder_hash,
                 },
                 block_size,
@@ -674,16 +669,16 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
     async fn process_block_request(&mut self, req: RequestMessage<TYPES>) {
         let requested_view_number = req.requested_view_number;
         // If a spawned clone is active then it will handle the request, otherwise the highest view num builder will handle
-        if requested_view_number == self.built_from_proposed_block.view_number {
+        if requested_view_number == self.parent_block_references.view_number {
             tracing::info!(
                 "Request handled by builder with view {}@{:?} for (view_num: {:?})",
-                self.built_from_proposed_block.vid_commitment,
-                self.built_from_proposed_block.view_number,
+                self.parent_block_references.vid_commitment,
+                self.parent_block_references.view_number,
                 requested_view_number
             );
             let response = self
                 .build_block(BuilderStateId {
-                    parent_commitment: self.built_from_proposed_block.vid_commitment,
+                    parent_commitment: self.parent_block_references.vid_commitment,
                     parent_view: requested_view_number,
                 })
                 .await;
@@ -704,7 +699,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                     let builder_hash = response.id.hash.clone();
                     self.global_state.write_arc().await.update_global_state(
                         BuilderStateId {
-                            parent_commitment: self.built_from_proposed_block.vid_commitment,
+                            parent_commitment: self.parent_block_references.vid_commitment,
                             parent_view: requested_view_number,
                         },
                         response,
@@ -716,7 +711,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                         Ok(_sent) => {
                             tracing::info!(
                                 "Builder {:?} Sent response to the request{:?} with builder hash {:?}",
-                                self.built_from_proposed_block.view_number,
+                                self.parent_block_references.view_number,
                                 req,
                                 builder_hash
                             );
@@ -724,7 +719,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                         Err(e) => {
                             tracing::warn!(
                                 "Builder {:?} failed to send response to {:?} with builder hash {:?}, Err: {:?}",
-                                self.built_from_proposed_block.view_number,
+                                self.parent_block_references.view_number,
                                 req,
                                 builder_hash,
                                 e
@@ -739,27 +734,27 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         } else {
             tracing::debug!(
                 "Builder {:?} Requested Builder commitment does not match the built_from_view, so ignoring it",
-                 self.built_from_proposed_block.view_number);
+                 self.parent_block_references.view_number);
         }
     }
     #[tracing::instrument(skip_all, name = "event loop",
-                                    fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
+                                    fields(builder_parent_block_references = %self.parent_block_references))]
     pub fn event_loop(mut self) {
         let _builder_handle = async_spawn(async move {
             loop {
                 tracing::debug!(
                     "Builder {:?} event loop",
-                    self.built_from_proposed_block.view_number
+                    self.parent_block_references.view_number
                 );
                 futures::select! {
                     req = self.req_receiver.next() => {
-                        tracing::debug!("Received request msg in builder {:?}: {:?}", self.built_from_proposed_block.view_number, req);
+                        tracing::debug!("Received request msg in builder {:?}: {:?}", self.parent_block_references.view_number, req);
                         match req {
                             Some(req) => {
                                 if let MessageType::RequestMessage(req) = req {
                                     tracing::debug!(
                                         "Received request msg in builder {:?}: {:?}",
-                                        self.built_from_proposed_block.view_number,
+                                        self.parent_block_references.view_number,
                                         req
                                     );
                                     self.process_block_request(req).await;
@@ -776,7 +771,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                         match da {
                             Some(da) => {
                                 if let MessageType::DaProposalMessage(rda_msg) = da {
-                                    tracing::debug!("Received da proposal msg in builder {:?}:\n {:?}", self.built_from_proposed_block, rda_msg.view_number);
+                                    tracing::debug!("Received da proposal msg in builder {:?}:\n {:?}", self.parent_block_references, rda_msg.view_number);
                                     self.process_da_proposal(rda_msg).await;
                                 } else {
                                     tracing::warn!("Unexpected message on da proposals channel: {:?}", da);
@@ -791,7 +786,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                         match qc {
                             Some(qc) => {
                                 if let MessageType::QuorumProposalMessage(rqc_msg) = qc {
-                                    tracing::debug!("Received quorum proposal msg in builder {:?}:\n {:?} for view ", self.built_from_proposed_block, rqc_msg.proposal.data.view_number);
+                                    tracing::debug!("Received quorum proposal msg in builder {:?}:\n {:?} for view ", self.parent_block_references, rqc_msg.proposal.data.view_number);
                                     self.process_quorum_proposal(rqc_msg).await;
                                 } else {
                                     tracing::warn!("Unexpected message on quorum proposals channel: {:?}", qc);
@@ -809,23 +804,23 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                                     let latest_decide_view_num = rdecide_msg.latest_decide_view_number;
                                     tracing::debug!("Received decide msg view {:?} in builder {:?}",
                                         &latest_decide_view_num,
-                                        self.built_from_proposed_block);
+                                        self.parent_block_references);
                                     let decide_status = self.process_decide_event(rdecide_msg).await;
                                     match decide_status{
                                         Some(Status::ShouldExit) => {
                                             tracing::info!("Exiting builder {:?} with decide view {:?}",
-                                                self.built_from_proposed_block,
+                                                self.parent_block_references,
                                                 &latest_decide_view_num);
                                             return;
                                         }
                                         Some(Status::ShouldContinue) => {
                                             tracing::debug!("Continuing builder {:?}",
-                                                self.built_from_proposed_block);
+                                                self.parent_block_references);
                                             continue;
                                         }
                                         None => {
                                             tracing::warn!("decide_status was None; Continuing builder {:?}",
-                                                self.built_from_proposed_block);
+                                                self.parent_block_references);
                                             continue;
                                         }
                                     }
@@ -855,7 +850,7 @@ pub enum MessageType<TYPES: NodeType> {
 #[allow(clippy::too_many_arguments)]
 impl<TYPES: NodeType> BuilderState<TYPES> {
     pub fn new(
-        built_from_proposed_block: BuiltFromProposedBlock<TYPES>,
+        parent_block_references: ParentBlockReferences<TYPES>,
         receivers: &BroadcastReceivers<TYPES>,
         req_receiver: BroadcastReceiver<MessageType<TYPES>>,
         tx_queue: Vec<Arc<ReceivedTransaction<TYPES>>>,
@@ -869,7 +864,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         let txns_in_queue: HashSet<_> = tx_queue.iter().map(|tx| tx.commit).collect();
         BuilderState {
             txns_in_queue,
-            built_from_proposed_block,
+            parent_block_references,
             req_receiver,
             tx_queue,
             global_state,
@@ -894,7 +889,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         BuilderState {
             included_txns,
             txns_in_queue: self.txns_in_queue.clone(),
-            built_from_proposed_block: self.built_from_proposed_block.clone(),
+            parent_block_references: self.parent_block_references.clone(),
             decide_receiver: self.decide_receiver.clone(),
             da_proposal_receiver: self.da_proposal_receiver.clone(),
             qc_receiver: self.qc_receiver.clone(),

--- a/crates/marketplace/src/testing/mod.rs
+++ b/crates/marketplace/src/testing/mod.rs
@@ -35,7 +35,7 @@ use hotshot_example_types::{
 use serde::{Deserialize, Serialize};
 
 use crate::service::{broadcast_channels, GlobalState};
-use crate::utils::BuiltFromProposedBlock;
+use crate::utils::ParentBlockReferences;
 use async_lock::RwLock;
 use committable::{Commitment, CommitmentBoundsArkless, Committable};
 use std::sync::Arc;
@@ -75,7 +75,7 @@ async fn start_builder_state(
 
     let genesis_vid_commitment = vid_commitment(&[], num_storage_nodes);
     let genesis_builder_commitment = BuilderCommitment::from_bytes([]);
-    let built_from_info = BuiltFromProposedBlock {
+    let parent_block_references = ParentBlockReferences {
         view_number: ViewNumber::genesis(),
         vid_commitment: genesis_vid_commitment,
         leaf_commit: Commitment::<Leaf<TestTypes>>::default_commitment_no_preimage(),
@@ -92,7 +92,7 @@ async fn start_builder_state(
 
     // instantiate the bootstrap builder state
     let builder_state = BuilderState::<TestTypes>::new(
-        built_from_info,
+        parent_block_references,
         &receivers,
         bootstrap_receiver,
         Vec::new(),

--- a/crates/marketplace/src/utils.rs
+++ b/crates/marketplace/src/utils.rs
@@ -123,9 +123,9 @@ impl<TYPES: NodeType> std::fmt::Display for BuilderStateId<TYPES> {
     }
 }
 
-/// Builder State to hold the state of the builder
+/// References to the parent block that is extended to spawn the new builder state.
 #[derive(Debug, Clone)]
-pub struct BuiltFromProposedBlock<TYPES: NodeType> {
+pub struct ParentBlockReferences<TYPES: NodeType> {
     pub view_number: TYPES::Time,
     pub vid_commitment: VidCommitment,
     pub leaf_commit: Commitment<Leaf<TYPES>>,
@@ -133,7 +133,7 @@ pub struct BuiltFromProposedBlock<TYPES: NodeType> {
 }
 
 // implement display for the derived info
-impl<TYPES: NodeType> std::fmt::Display for BuiltFromProposedBlock<TYPES> {
+impl<TYPES: NodeType> std::fmt::Display for ParentBlockReferences<TYPES> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "View Number: {:?}", self.view_number)
     }


### PR DESCRIPTION
Closes #136.

### This PR:
* Renames `BuiltFromProposedBlock` to `ParentBlockReferences`.
* Replaces `BuiltFromProposedBlock` with leaf commitment in the `spawned_builder_states` field of `GlobalState`.
* Updates relevant documentation.

### This PR does not:
* Changes any state spawning logic.

### Key places to review:
* `crates/marketplace/src/builder_state.rs`.
* `crates/marketplace/src/service.rs`.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
