### PR TITLE
Update legacy Builder to return empty blocks when transactions have been submitted within the last 4 blocks

### DIFF
--- a/crates/legacy/src/builder_state.rs
+++ b/crates/legacy/src/builder_state.rs
@@ -645,11 +645,11 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         let block_payload =
             <TYPES::BlockPayload as BlockPayload<TYPES>>::from_bytes(encoded_txns, metadata);
         let txn_commitments = block_payload.transaction_commitments(metadata);
+        self.view_txn_count_history.set_value(txn_commitments.len());
 
         self.included_txns.extend(txn_commitments);
         self.tx_queue
             .retain(|tx| self.included_txns.contains(&tx.commit));
-        self.view_txn_count_history.current += block_payload.num_transactions(metadata);
 
         // register the spawned builder state to spawned_builder_states in the global state
         self.global_state.write_arc().await.register_builder_state(
@@ -1073,7 +1073,6 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                         continue;
                     }
                     self.included_txns.insert(tx.commit);
-                    self.view_txn_count_history.current += 1;
                     self.tx_queue.push_back(tx);
                 }
                 Err(async_broadcast::TryRecvError::Empty)

--- a/crates/legacy/src/builder_state.rs
+++ b/crates/legacy/src/builder_state.rs
@@ -645,11 +645,12 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         let block_payload =
             <TYPES::BlockPayload as BlockPayload<TYPES>>::from_bytes(encoded_txns, metadata);
         let txn_commitments = block_payload.transaction_commitments(metadata);
-        self.view_txn_count_history.set_value(txn_commitments.len());
+        self.view_txn_count_history
+            .set_value(block_payload.num_transactions(metadata));
 
         self.included_txns.extend(txn_commitments);
         self.tx_queue
-            .retain(|tx| self.included_txns.contains(&tx.commit));
+            .retain(|tx| !self.included_txns.contains(&tx.commit));
 
         // register the spawned builder state to spawned_builder_states in the global state
         self.global_state.write_arc().await.register_builder_state(

--- a/crates/legacy/src/builder_state.rs
+++ b/crates/legacy/src/builder_state.rs
@@ -748,11 +748,11 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         // be included, because it alone goes over sequencer's block size limit.
         // We need to drop it and mark as "included" so that if we receive
         // it again we don't even bother with it.
-        if actual_txn_count == 0 && !self.tx_queue.is_empty() {
+        if actual_txn_count == 0 {
             if let Some(txn) = self.tx_queue.pop_front() {
                 self.included_txns.insert(txn.commit);
+                return None;
             };
-            return None;
         }
 
         // insert the recently built block into the builder commitments

--- a/crates/legacy/src/lib.rs
+++ b/crates/legacy/src/lib.rs
@@ -27,6 +27,140 @@ use hotshot_builder_api::v0_1::builder::BuildError;
 use hotshot_types::{
     data::Leaf, traits::node_implementation::NodeType, utils::BuilderCommitment, vid::VidCommitment,
 };
+use std::{
+    collections::HashSet,
+    hash::Hash,
+    mem,
+    time::{Duration, Instant},
+};
+
+/// A set that allows for time-based garbage collection,
+/// implemented as three sets that are periodically shifted right.
+/// Garage collection is triggered by calling [`Self::rotate`].
+#[derive(Clone, Debug)]
+pub struct RotatingSet<T>
+where
+    T: PartialEq + Eq + Hash + Clone,
+{
+    fresh: HashSet<T>,
+    stale: HashSet<T>,
+    expiring: HashSet<T>,
+    last_rotation: Instant,
+    period: Duration,
+}
+
+impl<T> RotatingSet<T>
+where
+    T: PartialEq + Eq + Hash + Clone,
+{
+    /// Construct a new `RotatingSet`
+    pub fn new(period: Duration) -> Self {
+        Self {
+            fresh: HashSet::new(),
+            stale: HashSet::new(),
+            expiring: HashSet::new(),
+            last_rotation: Instant::now(),
+            period,
+        }
+    }
+
+    /// Returns `true` if the key is contained in the set
+    pub fn contains(&self, key: &T) -> bool {
+        self.fresh.contains(key) || self.stale.contains(key) || self.expiring.contains(key)
+    }
+
+    /// Insert a `key` into the set. Doesn't trigger garbage collection
+    pub fn insert(&mut self, value: T) {
+        self.fresh.insert(value);
+    }
+
+    /// Force garbage collection, even if the time elapsed since
+    ///  the last garbage collection is less than `self.period`
+    pub fn force_rotate(&mut self) {
+        let now_stale = mem::take(&mut self.fresh);
+        let now_expiring = mem::replace(&mut self.stale, now_stale);
+        self.expiring = now_expiring;
+        self.last_rotation = Instant::now();
+    }
+
+    /// Trigger garbage collection.
+    pub fn rotate(&mut self) -> bool {
+        if self.last_rotation.elapsed() > self.period {
+            self.force_rotate();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<T> Extend<T> for RotatingSet<T>
+where
+    T: PartialEq + Eq + Hash + Clone,
+{
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.fresh.extend(iter)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RotatingData<T> {
+    pub current: T,
+    pub fresh: T,
+    pub stale: T,
+    pub expiring: T,
+}
+
+impl<T> Copy for RotatingData<T> where T: Copy {}
+
+impl<T> Default for RotatingData<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            current: T::default(),
+            fresh: T::default(),
+            stale: T::default(),
+            expiring: T::default(),
+        }
+    }
+}
+
+impl<T> RotatingData<T> where T: Clone + Default {}
+
+impl<T> RotatingData<T>
+where
+    T: PartialEq + Eq + Hash + Clone + Default,
+{
+    pub fn new() -> Self {
+        Self::with_initial_value(Default::default())
+    }
+
+    pub fn cycle_clone(&self) -> Self {
+        Self {
+            current: T::default(),
+            fresh: self.current.clone(),
+            stale: self.fresh.clone(),
+            expiring: self.stale.clone(),
+        }
+    }
+
+    pub fn with_initial_value(value: T) -> Self {
+        Self {
+            current: value.clone(),
+            fresh: T::default(),
+            stale: T::default(),
+            expiring: T::default(),
+        }
+    }
+}
+
+impl RotatingData<usize> {
+    pub fn is_zero(&self) -> bool {
+        self.current == 0 && self.fresh == 0 && self.stale == 0 && self.expiring == 0
+    }
+}
 
 /// WaitAndKeep is a helper enum that allows for the lazy polling of a single
 /// value from an unbound receiver.

--- a/crates/legacy/src/lib.rs
+++ b/crates/legacy/src/lib.rs
@@ -154,6 +154,10 @@ where
             expiring: T::default(),
         }
     }
+
+    pub fn set_value(&mut self, value: T) {
+        self.current = value;
+    }
 }
 
 impl RotatingData<usize> {

--- a/crates/legacy/src/testing.rs
+++ b/crates/legacy/src/testing.rs
@@ -3,3 +3,6 @@
 //
 
 pub mod basic_test;
+
+#[cfg(test)]
+pub mod finalization_test;

--- a/crates/legacy/src/testing/finalization_test.rs
+++ b/crates/legacy/src/testing/finalization_test.rs
@@ -1,0 +1,454 @@
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+
+use crate::{
+    builder_state::{DaProposalMessage, QCMessage},
+    service::{GlobalState, ProxyGlobalState, ReceivedTransaction},
+    BuilderStateId, ParentBlockReferences,
+};
+use async_broadcast::{broadcast, Sender};
+use async_lock::RwLock;
+use committable::Commitment;
+use hotshot::{
+    traits::BlockPayload,
+    types::{BLSPubKey, SignatureKey},
+};
+use hotshot_builder_api::{
+    v0_2::{block_info::AvailableBlockInfo, data_source::BuilderDataSource},
+    v0_3::{builder::BuildError, data_source::AcceptsTxnSubmits},
+};
+use hotshot_example_types::{
+    block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
+    node_types::TestTypes,
+    state_types::{TestInstanceState, TestValidatedState},
+};
+use hotshot_types::{
+    data::{DaProposal, QuorumProposal, ViewNumber},
+    message::Proposal,
+    simple_certificate::QuorumCertificate,
+    traits::{
+        block_contents::{vid_commitment, BlockHeader},
+        node_implementation::ConsensusTime,
+    },
+    utils::BuilderCommitment,
+};
+use sha2::{Digest, Sha256};
+
+use super::basic_test::{BuilderState, MessageType};
+
+type TestSetup = (
+    ProxyGlobalState<TestTypes>,
+    async_broadcast::Sender<MessageType<TestTypes>>,
+    async_broadcast::Sender<MessageType<TestTypes>>,
+    async_broadcast::Sender<MessageType<TestTypes>>,
+    async_broadcast::Sender<Arc<ReceivedTransaction<TestTypes>>>,
+);
+
+const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
+const TEST_NUM_CONSENSUS_RETRIES: usize = 4;
+
+/// [setup_builder_for_test] sets up a test environment for the builder state.
+/// It returns a tuple containing the proxy global state, the sender for decide
+/// messages, the sender for data availability proposals,
+fn setup_builder_for_test() -> TestSetup {
+    let (req_sender, req_receiver) = broadcast(32);
+    let (tx_sender, tx_receiver) = broadcast(32);
+
+    let bootstrap_builder_state_id = BuilderStateId::<TestTypes> {
+        parent_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+        view: ViewNumber::genesis(),
+    };
+
+    let global_state = Arc::new(RwLock::new(GlobalState::new(
+        req_sender,
+        tx_sender.clone(),
+        bootstrap_builder_state_id.parent_commitment,
+        bootstrap_builder_state_id.view,
+        bootstrap_builder_state_id.view,
+        0,
+    )));
+
+    let max_api_duration = Duration::from_millis(100);
+
+    let proxy_global_state = ProxyGlobalState::new(
+        global_state.clone(),
+        BLSPubKey::generated_from_seed_indexed([1; 32], 0),
+        max_api_duration,
+    );
+
+    let (decide_sender, decide_receiver) = broadcast(32);
+    let (da_proposal_sender, da_proposal_receiver) = broadcast(32);
+    let (quorum_proposal_sender, quorum_proposal_receiver) = broadcast(32);
+    let bootstrap_builder_state = BuilderState::<TestTypes>::new(
+        ParentBlockReferences {
+            vid_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+            view_number: ViewNumber::genesis(),
+            leaf_commit: Commitment::from_raw([0; 32]),
+            builder_commitment: BuilderCommitment::from_bytes([0; 32]),
+        },
+        decide_receiver,
+        da_proposal_receiver,
+        quorum_proposal_receiver,
+        req_receiver,
+        tx_receiver,
+        Default::default(),
+        global_state.clone(),
+        NonZeroUsize::new(TEST_NUM_NODES_IN_VID_COMPUTATION).unwrap(),
+        Duration::from_millis(40),
+        1,
+        Default::default(),
+        Duration::from_secs(1),
+        Default::default(),
+    );
+
+    bootstrap_builder_state.event_loop();
+
+    (
+        proxy_global_state,
+        decide_sender,
+        da_proposal_sender,
+        quorum_proposal_sender,
+        tx_sender,
+    )
+}
+
+/// [process_available_blocks_round] processes available rounds for a given
+/// round. It returns the number of attempts made to get the available blocks
+/// and the result of the available blocks.
+///
+/// By default Consensus will retry 3-4 times to get available blocks from the
+/// Builder.
+async fn process_available_blocks_round(
+    proxy_global_state: &ProxyGlobalState<TestTypes>,
+    builder_state_id: BuilderStateId<TestTypes>,
+    round: u64,
+) -> (
+    usize,
+    Result<Vec<AvailableBlockInfo<TestTypes>>, BuildError>,
+) {
+    let (leader_pub, leader_priv) = BLSPubKey::generated_from_seed_indexed([0; 32], round);
+
+    let current_commit_signature = <BLSPubKey as SignatureKey>::sign(
+        &leader_priv,
+        builder_state_id.parent_commitment.as_ref(),
+    )
+    .unwrap();
+
+    // Simulate Consensus retries
+
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+
+        let available_blocks_result = proxy_global_state
+            .available_blocks(
+                &builder_state_id.parent_commitment,
+                builder_state_id.view.u64(),
+                leader_pub,
+                &current_commit_signature,
+            )
+            .await;
+
+        if available_blocks_result.is_ok() {
+            return (attempt, available_blocks_result);
+        }
+
+        if attempt >= TEST_NUM_CONSENSUS_RETRIES {
+            return (attempt, available_blocks_result);
+        }
+    }
+}
+
+async fn progress_round_with_available_block_info(
+    proxy_global_state: &ProxyGlobalState<TestTypes>,
+    available_block_info: AvailableBlockInfo<TestTypes>,
+    builder_state_id: BuilderStateId<TestTypes>,
+    round: u64,
+    da_proposal_sender: &Sender<MessageType<TestTypes>>,
+    quorum_proposal_sender: &Sender<MessageType<TestTypes>>,
+) -> BuilderStateId<TestTypes> {
+    let (leader_pub, leader_priv) = BLSPubKey::generated_from_seed_indexed([0; 32], round);
+
+    let signed_parent_commitment =
+        <BLSPubKey as SignatureKey>::sign(&leader_priv, available_block_info.block_hash.as_ref())
+            .unwrap();
+
+    let claim_block_result = proxy_global_state
+        .claim_block(
+            &available_block_info.block_hash,
+            builder_state_id.view.u64(),
+            leader_pub,
+            &signed_parent_commitment,
+        )
+        .await
+        .unwrap_or_else(|_| panic!("claim block should succeed for round {round}"));
+
+    let _claim_block_header_result = proxy_global_state
+        .claim_block_header_input(
+            &available_block_info.block_hash,
+            builder_state_id.view.u64(),
+            leader_pub,
+            &signed_parent_commitment,
+        )
+        .await
+        .unwrap_or_else(|_| panic!("claim block header input should succeed for round {round}"));
+
+    progress_round_with_transactions(
+        builder_state_id,
+        claim_block_result.block_payload.transactions,
+        round,
+        da_proposal_sender,
+        quorum_proposal_sender,
+    )
+    .await
+}
+
+async fn progress_round_without_available_block_info(
+    builder_state_id: BuilderStateId<TestTypes>,
+    round: u64,
+    da_proposal_sender: &Sender<MessageType<TestTypes>>,
+    quorum_proposal_sender: &Sender<MessageType<TestTypes>>,
+) -> BuilderStateId<TestTypes> {
+    progress_round_with_transactions(
+        builder_state_id,
+        vec![],
+        round,
+        da_proposal_sender,
+        quorum_proposal_sender,
+    )
+    .await
+}
+
+async fn progress_round_with_transactions(
+    builder_state_id: BuilderStateId<TestTypes>,
+    transactions: Vec<TestTransaction>,
+    round: u64,
+    da_proposal_sender: &Sender<MessageType<TestTypes>>,
+    quorum_proposal_sender: &Sender<MessageType<TestTypes>>,
+) -> BuilderStateId<TestTypes> {
+    let (leader_pub, leader_priv) = BLSPubKey::generated_from_seed_indexed([0; 32], round);
+    let encoded_transactions = TestTransaction::encode(&transactions);
+    let next_view = builder_state_id.view + 1;
+
+    // Create and send the DA Proposals and Quorum Proposals
+    {
+        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
+        let da_signature =
+        <TestTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey::sign(
+            &leader_priv,
+            &encoded_transactions_hash,
+        )
+        .expect("should sign encoded transactions hash successfully");
+
+        da_proposal_sender
+            .broadcast(MessageType::DaProposalMessage(DaProposalMessage {
+                proposal: Arc::new(Proposal {
+                    data: DaProposal::<TestTypes> {
+                        encoded_transactions: encoded_transactions.clone().into(),
+                        metadata: TestMetadata,
+                        view_number: next_view,
+                    },
+                    signature: da_signature,
+                    _pd: Default::default(),
+                }),
+                sender: leader_pub,
+                total_nodes: TEST_NUM_NODES_IN_VID_COMPUTATION,
+            }))
+            .await
+            .expect("should broadcast DA Proposal successfully");
+
+        let payload_commitment =
+            vid_commitment(&encoded_transactions, TEST_NUM_NODES_IN_VID_COMPUTATION);
+
+        let (block_payload, metadata) =
+            <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
+                transactions,
+                &TestValidatedState::default(),
+                &TestInstanceState::default(),
+            )
+            .await
+            .unwrap();
+
+        let builder_commitment = <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(
+            &block_payload,
+            &metadata,
+        );
+
+        let block_header = TestBlockHeader {
+            block_number: round,
+            payload_commitment,
+            builder_commitment,
+            timestamp: round,
+        };
+
+        let qc_proposal = QuorumProposal::<TestTypes> {
+            block_header,
+            view_number: next_view,
+            justify_qc: QuorumCertificate::<TestTypes>::genesis(
+                &TestValidatedState::default(),
+                &TestInstanceState::default(),
+            )
+            .await,
+            upgrade_certificate: None,
+            proposal_certificate: None,
+        };
+
+        let payload_vid_commitment =
+            <TestBlockHeader as BlockHeader<TestTypes>>::payload_commitment(
+                &qc_proposal.block_header,
+            );
+
+        let qc_signature = <TestTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey::sign(
+                        &leader_priv,
+                        payload_vid_commitment.as_ref(),
+                        ).expect("Failed to sign payload commitment while preparing QC proposal");
+
+        quorum_proposal_sender
+            .broadcast(MessageType::QCMessage(QCMessage {
+                proposal: Arc::new(Proposal {
+                    data: qc_proposal.clone(),
+                    signature: qc_signature,
+                    _pd: Default::default(),
+                }),
+                sender: leader_pub,
+            }))
+            .await
+            .expect("should broadcast QC Proposal successfully");
+
+        BuilderStateId {
+            parent_commitment: payload_vid_commitment,
+            view: next_view,
+        }
+    }
+}
+
+#[async_std::test]
+async fn test_empty_block_rate() {
+    let (proxy_global_state, _, da_proposal_sender, quorum_proposal_sender, _) =
+        setup_builder_for_test();
+
+    let mut current_builder_state_id = BuilderStateId::<TestTypes> {
+        parent_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+        view: ViewNumber::genesis(),
+    };
+
+    for round in 0..10 {
+        let (attempts, available_available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, TEST_NUM_CONSENSUS_RETRIES,
+            "Consensus should retry {TEST_NUM_CONSENSUS_RETRIES} times to get available blocks"
+        );
+        assert!(available_available_blocks_result.is_err());
+
+        current_builder_state_id = progress_round_without_available_block_info(
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+}
+
+#[async_std::test]
+async fn test_eager_block_rate() {
+    let (proxy_global_state, _, da_proposal_sender, quorum_proposal_sender, _) =
+        setup_builder_for_test();
+
+    let mut current_builder_state_id = BuilderStateId::<TestTypes> {
+        parent_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+        view: ViewNumber::genesis(),
+    };
+
+    // Round 0
+    {
+        let round = 0;
+        let (attempts, available_available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, TEST_NUM_CONSENSUS_RETRIES,
+            "Consensus should retry {TEST_NUM_CONSENSUS_RETRIES} times to get available blocks"
+        );
+        assert!(
+            available_available_blocks_result.is_err(),
+            "builder should not propose empty blocks"
+        );
+
+        current_builder_state_id = progress_round_without_available_block_info(
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+
+    // Round 1, submit a single transaction
+    {
+        proxy_global_state
+            .submit_txns(vec![TestTransaction::new(vec![1])])
+            .await
+            .expect("should submit transaction without issue");
+    }
+
+    for round in 1..6 {
+        let (attempts, available_available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, 1,
+            "Consensus should not have needed to retry at all"
+        );
+        assert!(
+            available_available_blocks_result.is_ok(),
+            "builder should be proposing empty blocks"
+        );
+
+        current_builder_state_id = progress_round_with_available_block_info(
+            &proxy_global_state,
+            available_available_blocks_result.unwrap()[0].clone(),
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+
+    for round in 6..10 {
+        let (attempts, available_available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, TEST_NUM_CONSENSUS_RETRIES,
+            "Consensus should have retries {TEST_NUM_CONSENSUS_RETRIES} times"
+        );
+        assert!(available_available_blocks_result.is_err());
+
+        current_builder_state_id = progress_round_without_available_block_info(
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+}

--- a/crates/legacy/src/testing/finalization_test.rs
+++ b/crates/legacy/src/testing/finalization_test.rs
@@ -18,7 +18,7 @@ use hotshot_builder_api::{
 };
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
-    node_types::TestTypes,
+    node_types::{TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_types::{
@@ -239,12 +239,16 @@ async fn progress_round_with_transactions(
         )
         .expect("should sign encoded transactions hash successfully");
 
+        let metadata = TestMetadata {
+            num_transactions: transactions.len() as u64,
+        };
+
         da_proposal_sender
             .broadcast(MessageType::DaProposalMessage(DaProposalMessage {
                 proposal: Arc::new(Proposal {
                     data: DaProposal::<TestTypes> {
                         encoded_transactions: encoded_transactions.clone().into(),
-                        metadata: TestMetadata,
+                        metadata,
                         view_number: next_view,
                     },
                     signature: da_signature,
@@ -278,12 +282,14 @@ async fn progress_round_with_transactions(
             payload_commitment,
             builder_commitment,
             timestamp: round,
+            metadata,
+            random: 0,
         };
 
         let qc_proposal = QuorumProposal::<TestTypes> {
             block_header,
             view_number: next_view,
-            justify_qc: QuorumCertificate::<TestTypes>::genesis(
+            justify_qc: QuorumCertificate::<TestTypes>::genesis::<TestVersions>(
                 &TestValidatedState::default(),
                 &TestInstanceState::default(),
             )


### PR DESCRIPTION
Closes #101
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Updates the legacy builder to keep track of the number of transactions submitted in the last 4 rounds in order to avoid sending an error response instead of empty blocks in these cases.

The Consensus protocol currently requires four rounds of iteration in order for existing transactions to go through.  So in the cases where we have limited number of transactions going through it can take us a delayed four rounds to finalize transactions.  The reason for this delay is due to the Builder returning an error instead of empty blocks.  Now returning an error is still desired when we do not have any recent transactions, as otherwise we would be creating empty blocks faster when not neccessary.  But when the last 4 rounds have transactions, this behavior is not desired.

<!-- ### This PR does not: -->
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
