### PR TITLE
Rename `qc` to `quorum` where appropriate

### DIFF
--- a/crates/marketplace/src/builder_state.rs
+++ b/crates/marketplace/src/builder_state.rs
@@ -878,25 +878,31 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
 
     /// [event_loop_helper_handle_quorum_proposal] is a helper function that is used
     /// to handle incoming [MessageType]s, specifically [QuorumProposalMessage]s,
-    /// that are received by the [BuilderState::qc_receiver] channel.
-    async fn event_loop_helper_handle_quorum_proposal(&mut self, qc: Option<MessageType<TYPES>>) {
-        let Some(qc) = qc else {
+    /// that are received by the [BuilderState::quorum_proposal_receiver] channel.
+    async fn event_loop_helper_handle_quorum_proposal(
+        &mut self,
+        quorum: Option<MessageType<TYPES>>,
+    ) {
+        let Some(quorum) = quorum else {
             tracing::warn!("No more quorum proposal messages to consume");
             return;
         };
 
-        let MessageType::QuorumProposalMessage(rqc_msg) = qc else {
-            tracing::warn!("Unexpected message on quorum proposals channel: {:?}", qc);
+        let MessageType::QuorumProposalMessage(quorum_proposal_message) = quorum else {
+            tracing::warn!(
+                "Unexpected message on quorum proposals channel: {:?}",
+                quorum
+            );
             return;
         };
 
         tracing::debug!(
             "Received quorum proposal msg in builder {:?}:\n {:?} for view ",
             self.parent_block_references,
-            rqc_msg.proposal.data.view_number
+            quorum_proposal_message.proposal.data.view_number
         );
 
-        self.process_quorum_proposal(rqc_msg).await;
+        self.process_quorum_proposal(quorum_proposal_message).await;
     }
 
     /// [event_loop_helper_handle_decide] is a helper function that is used to

--- a/crates/marketplace/src/builder_state.rs
+++ b/crates/marketplace/src/builder_state.rs
@@ -54,7 +54,7 @@ pub struct DaProposalMessage<TYPES: NodeType> {
     pub builder_commitment: BuilderCommitment,
 }
 
-/// QC Message to be put on the quorum proposal channel
+/// Quorum proposal message to be put on the quorum proposal channel
 #[derive(Clone, Debug, PartialEq)]
 pub struct QuorumProposalMessage<TYPES: NodeType> {
     pub proposal: Arc<Proposal<TYPES, QuorumProposal<TYPES>>>,
@@ -125,7 +125,7 @@ pub struct BuilderState<TYPES: NodeType> {
     pub da_proposal_receiver: BroadcastReceiver<MessageType<TYPES>>,
 
     /// quorum proposal receiver
-    pub qc_receiver: BroadcastReceiver<MessageType<TYPES>>,
+    pub quorum_proposal_receiver: BroadcastReceiver<MessageType<TYPES>>,
 
     /// channel receiver for the block requests
     pub req_receiver: BroadcastReceiver<MessageType<TYPES>>,
@@ -404,7 +404,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                     self.spawn_clone_that_extends_self(da_msg, quorum_proposal)
                         .await;
                 } else {
-                    tracing::debug!("Not spawning a clone despite matching DA and QC payload commitments, as they corresponds to different view numbers");
+                    tracing::debug!("Not spawning a clone despite matching DA and quorum payload commitments, as they corresponds to different view numbers");
                 }
             } else {
                 e.insert(da_msg);
@@ -418,10 +418,10 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
     //#[tracing::instrument(skip_all, name = "Process Quorum Proposal")]
     #[tracing::instrument(skip_all, name = "process quorum proposal",
                                     fields(builder_parent_block_references = %self.parent_block_references))]
-    async fn process_quorum_proposal(&mut self, qc_msg: QuorumProposalMessage<TYPES>) {
+    async fn process_quorum_proposal(&mut self, quorum_msg: QuorumProposalMessage<TYPES>) {
         tracing::debug!(
-            "Builder Received QC Message for view {:?}",
-            qc_msg.proposal.data.view_number
+            "Builder Received Quorum proposal message for view {:?}",
+            quorum_msg.proposal.data.view_number
         );
 
         // Two cases to handle:
@@ -430,7 +430,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         // To handle both cases, we can have the highest view number builder state running
         // and only doing the insertion if and only if intended builder state for a particular view is not present
         // check the presence of quorum_proposal.data.view_number-1 in the spawned_builder_states list
-        let quorum_proposal = &qc_msg.proposal;
+        let quorum_proposal = &quorum_msg.proposal;
         let view_number = quorum_proposal.data.view_number;
         let payload_builder_commitment = quorum_proposal.data.block_header.builder_commitment();
 
@@ -439,7 +439,9 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             payload_builder_commitment
         );
 
-        // first check whether vid_commitment exists in the qc_payload_commit_to_qc hashmap, if yer, ignore it, otherwise validate it and later insert in
+        // first check whether vid_commitment exists in the
+        // `quorum_proposal_payload_commit_to_quorum_proposal` hashmap, if yes, ignore it,
+        // otherwise validate it and later insert in
         if let std::collections::hash_map::Entry::Vacant(e) = self
             .quorum_proposal_payload_commit_to_quorum_proposal
             .entry((payload_builder_commitment.clone(), view_number))
@@ -457,14 +459,14 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                 // also make sure we clone for the same view number( check incase payload commitments are same)
                 if da_proposal_info.view_number == view_number {
                     tracing::info!(
-                        "Spawning a clone from process QC proposal for view number: {:?}",
+                        "Spawning a clone from process Quorum proposal for view number: {:?}",
                         view_number
                     );
 
                     self.spawn_clone_that_extends_self(da_proposal_info, quorum_proposal.clone())
                         .await;
                 } else {
-                    tracing::debug!("Not spawning a clone despite matching DA and QC payload commitments, as they corresponds to different view numbers");
+                    tracing::debug!("Not spawning a clone despite matching DA and quorum payload commitments, as they corresponds to different view numbers");
                 }
             } else {
                 e.insert(quorum_proposal.clone());
@@ -491,7 +493,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             .await
         {
             tracing::debug!(
-                "{} is not the best fit for forking, {}@{}, so ignoring the QC proposal, and leaving it to another BuilderState",
+                "{} is not the best fit for forking, {}@{}, so ignoring the Quorum proposal, and leaving it to another BuilderState",
                 self.parent_block_references,
                 quorum_proposal.data.block_header.payload_commitment(),
                 quorum_proposal.data.view_number.u64(),
@@ -520,7 +522,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
     async fn process_decide_event(&mut self, decide_msg: DecideMessage<TYPES>) -> Option<Status> {
         // Exit out all the builder states if their parent_block_references.view_number is less than the latest_decide_view_number
         // The only exception is that we want to keep the highest view number builder state active to ensure that
-        // we have a builder state to handle the incoming DA and QC proposals
+        // we have a builder state to handle the incoming DA and Quorum proposals
         let decide_view_number = decide_msg.latest_decide_view_number;
 
         let retained_view_cutoff = self
@@ -796,14 +798,14 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
                             }
                         }
                     },
-                    qc = self.qc_receiver.next() => {
-                        match qc {
-                            Some(qc) => {
-                                if let MessageType::QuorumProposalMessage(rqc_msg) = qc {
-                                    tracing::debug!("Received quorum proposal msg in builder {:?}:\n {:?} for view ", self.parent_block_references, rqc_msg.proposal.data.view_number);
-                                    self.process_quorum_proposal(rqc_msg).await;
+                    quorum = self.quorum_proposal_receiver.next() => {
+                        match quorum {
+                            Some(quorum) => {
+                                if let MessageType::QuorumProposalMessage(rquorum_msg) = quorum {
+                                    tracing::debug!("Received quorum proposal msg in builder {:?}:\n {:?} for view ", self.parent_block_references, rquorum_msg.proposal.data.view_number);
+                                    self.process_quorum_proposal(rquorum_msg).await;
                                 } else {
-                                    tracing::warn!("Unexpected message on quorum proposals channel: {:?}", qc);
+                                    tracing::warn!("Unexpected message on quorum proposals channel: {:?}", quorum);
                                 }
                             }
                             None => {
@@ -892,7 +894,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             builder_commitments: HashSet::new(),
             decide_receiver: receivers.decide.activate_cloned(),
             da_proposal_receiver: receivers.da_proposal.activate_cloned(),
-            qc_receiver: receivers.quorum_proposal.activate_cloned(),
+            quorum_proposal_receiver: receivers.quorum_proposal.activate_cloned(),
             tx_receiver: receivers.transactions.activate_cloned(),
         }
     }
@@ -906,7 +908,7 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             parent_block_references: self.parent_block_references.clone(),
             decide_receiver: self.decide_receiver.clone(),
             da_proposal_receiver: self.da_proposal_receiver.clone(),
-            qc_receiver: self.qc_receiver.clone(),
+            quorum_proposal_receiver: self.quorum_proposal_receiver.clone(),
             req_receiver,
             da_proposal_payload_commit_to_da_proposal: HashMap::new(),
             quorum_proposal_payload_commit_to_quorum_proposal: HashMap::new(),
@@ -1118,10 +1120,11 @@ mod test {
             calc_proposal_msg(NUM_STORAGE_NODES, 0, None, transactions_2).await;
 
         // process quorum proposal first, so that later when process_da_proposal we can directly call `build_block` and skip storage
-        if let MessageType::QuorumProposalMessage(practice_qc_msg_2) = quorum_proposal_msg_2.clone()
+        if let MessageType::QuorumProposalMessage(practice_quorum_msg_2) =
+            quorum_proposal_msg_2.clone()
         {
             builder_state
-                .process_quorum_proposal(practice_qc_msg_2.clone())
+                .process_quorum_proposal(practice_quorum_msg_2.clone())
                 .await;
         } else {
             panic!("Not a quorum_proposal_message in correct format");
@@ -1182,21 +1185,22 @@ mod test {
         // call process_quorum_proposal without matching da proposal message
         // quorum_proposal_payload_commit_to_quorum_proposal should insert the message
         let mut correct_quorum_proposal_payload_commit_to_quorum_proposal = HashMap::new();
-        if let MessageType::QuorumProposalMessage(practice_qc_msg) = quorum_proposal_msg.clone() {
+        if let MessageType::QuorumProposalMessage(practice_quorum_msg) = quorum_proposal_msg.clone()
+        {
             builder_state
-                .process_quorum_proposal(practice_qc_msg.clone())
+                .process_quorum_proposal(practice_quorum_msg.clone())
                 .await;
             correct_quorum_proposal_payload_commit_to_quorum_proposal.insert(
                 (
-                    practice_qc_msg
+                    practice_quorum_msg
                         .proposal
                         .data
                         .block_header
                         .builder_commitment
                         .clone(),
-                    practice_qc_msg.proposal.data.view_number,
+                    practice_quorum_msg.proposal.data.view_number,
                 ),
-                practice_qc_msg.proposal,
+                practice_quorum_msg.proposal,
             );
         } else {
             panic!("Not a quorum_proposal_message in correct format");
@@ -1236,10 +1240,11 @@ mod test {
         }
 
         // process quorum proposal, and do the check
-        if let MessageType::QuorumProposalMessage(practice_qc_msg_2) = quorum_proposal_msg_2.clone()
+        if let MessageType::QuorumProposalMessage(practice_quorum_msg_2) =
+            quorum_proposal_msg_2.clone()
         {
             builder_state
-                .process_quorum_proposal(practice_qc_msg_2.clone())
+                .process_quorum_proposal(practice_quorum_msg_2.clone())
                 .await;
         } else {
             panic!("Not a quorum_proposal_message in correct format");

--- a/crates/marketplace/src/testing/mod.rs
+++ b/crates/marketplace/src/testing/mod.rs
@@ -207,18 +207,18 @@ pub async fn calc_proposal_msg(
         proposal_certificate: None,
     };
 
-    let qc_signature =
+    let quorum_signature =
         <TestTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey::sign(
             &private_key,
             block_vid_commitment.as_ref(),
         )
-        .expect("Failed to sign payload commitment while preparing QC proposal");
+        .expect("Failed to sign payload commitment while preparing Quorum proposal");
 
     let quorum_proposal_msg =
         MessageType::QuorumProposalMessage(QuorumProposalMessage::<TestTypes> {
             proposal: Arc::new(Proposal {
                 data: quorum_proposal.clone(),
-                signature: qc_signature,
+                signature: quorum_signature,
                 _pd: PhantomData,
             }),
             sender: pub_key,


### PR DESCRIPTION
Closes #88.

### This PR:
* Replaces `qc` with `quorum` in names and documentation.