### PR TITLE
Add behavior to allow for a grace period of empty blocks

### DIFF
--- a/crates/legacy/src/testing.rs
+++ b/crates/legacy/src/testing.rs
@@ -3,3 +3,5 @@
 //
 
 pub mod basic_test;
+
+pub mod finalization_test;

--- a/crates/legacy/src/testing/basic_test.rs
+++ b/crates/legacy/src/testing/basic_test.rs
@@ -139,7 +139,6 @@ mod tests {
             Arc::new(TestInstanceState::default()),
             Duration::from_millis(100),
             Arc::new(TestValidatedState::default()),
-            None,
         );
 
         // Kick off async look for the bootstrap builder state

--- a/crates/legacy/src/testing/basic_test.rs
+++ b/crates/legacy/src/testing/basic_test.rs
@@ -139,6 +139,7 @@ mod tests {
             Arc::new(TestInstanceState::default()),
             Duration::from_millis(100),
             Arc::new(TestValidatedState::default()),
+            None,
         );
 
         // Kick off async look for the bootstrap builder state

--- a/crates/legacy/src/testing/finalization_test.rs
+++ b/crates/legacy/src/testing/finalization_test.rs
@@ -1,0 +1,550 @@
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+
+use crate::{
+    builder_state::{DaProposalMessage, QuorumProposalMessage},
+    service::{GlobalState, ProxyGlobalState, ReceivedTransaction},
+    BuilderStateId, ParentBlockReferences,
+};
+use async_broadcast::{broadcast, Sender};
+use async_lock::RwLock;
+use committable::Commitment;
+use hotshot::{
+    traits::BlockPayload,
+    types::{BLSPubKey, SignatureKey},
+};
+use hotshot_builder_api::{
+    v0_2::{block_info::AvailableBlockInfo, data_source::BuilderDataSource},
+    v0_3::{builder::BuildError, data_source::AcceptsTxnSubmits},
+};
+use hotshot_example_types::{
+    block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
+    node_types::{TestTypes, TestVersions},
+    state_types::{TestInstanceState, TestValidatedState},
+};
+use hotshot_types::{
+    data::{DaProposal, QuorumProposal, ViewNumber},
+    message::Proposal,
+    simple_certificate::QuorumCertificate,
+    traits::{
+        block_contents::{vid_commitment, BlockHeader},
+        node_implementation::ConsensusTime,
+    },
+    utils::BuilderCommitment,
+};
+use sha2::{Digest, Sha256};
+
+use super::basic_test::{BuilderState, MessageType};
+
+type TestSetup = (
+    ProxyGlobalState<TestTypes>,
+    async_broadcast::Sender<MessageType<TestTypes>>,
+    async_broadcast::Sender<MessageType<TestTypes>>,
+    async_broadcast::Sender<MessageType<TestTypes>>,
+    async_broadcast::Sender<Arc<ReceivedTransaction<TestTypes>>>,
+);
+
+const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
+const TEST_NUM_CONSENSUS_RETRIES: usize = 4;
+
+/// [setup_builder_for_test] sets up a test environment for the builder state.
+/// It returns a tuple containing the proxy global state, the sender for decide
+/// messages, the sender for data availability proposals,
+fn setup_builder_for_test(allow_empty_block_period: Option<u64>) -> TestSetup {
+    let (req_sender, req_receiver) = broadcast(32);
+    let (tx_sender, tx_receiver) = broadcast(32);
+
+    let bootstrap_builder_state_id = BuilderStateId::<TestTypes> {
+        parent_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+        view: ViewNumber::genesis(),
+    };
+
+    let global_state = Arc::new(RwLock::new(GlobalState::new(
+        req_sender,
+        tx_sender.clone(),
+        bootstrap_builder_state_id.parent_commitment,
+        bootstrap_builder_state_id.view,
+        bootstrap_builder_state_id.view,
+        0,
+    )));
+
+    let max_api_duration = Duration::from_millis(100);
+
+    let proxy_global_state = ProxyGlobalState::new(
+        global_state.clone(),
+        BLSPubKey::generated_from_seed_indexed([1; 32], 0),
+        max_api_duration,
+    );
+
+    let (decide_sender, decide_receiver) = broadcast(32);
+    let (da_proposal_sender, da_proposal_receiver) = broadcast(32);
+    let (quorum_proposal_sender, quorum_proposal_receiver) = broadcast(32);
+    let bootstrap_builder_state = BuilderState::<TestTypes>::new(
+        ParentBlockReferences {
+            vid_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+            view_number: ViewNumber::genesis(),
+            leaf_commit: Commitment::from_raw([0; 32]),
+            builder_commitment: BuilderCommitment::from_bytes([0; 32]),
+        },
+        decide_receiver,
+        da_proposal_receiver,
+        quorum_proposal_receiver,
+        req_receiver,
+        tx_receiver,
+        Default::default(),
+        global_state.clone(),
+        NonZeroUsize::new(TEST_NUM_NODES_IN_VID_COMPUTATION).unwrap(),
+        Duration::from_millis(40),
+        1,
+        Default::default(),
+        Duration::from_secs(1),
+        Default::default(),
+        allow_empty_block_period,
+    );
+
+    bootstrap_builder_state.event_loop();
+
+    (
+        proxy_global_state,
+        decide_sender,
+        da_proposal_sender,
+        quorum_proposal_sender,
+        tx_sender,
+    )
+}
+
+/// [process_available_blocks_round] processes available rounds for a given
+/// round. It returns the number of attempts made to get the available blocks
+/// and the result of the available blocks.
+///
+/// By default Consensus will retry 3-4 times to get available blocks from the
+/// Builder.
+async fn process_available_blocks_round(
+    proxy_global_state: &ProxyGlobalState<TestTypes>,
+    builder_state_id: BuilderStateId<TestTypes>,
+    round: u64,
+) -> (
+    usize,
+    Result<Vec<AvailableBlockInfo<TestTypes>>, BuildError>,
+) {
+    let (leader_pub, leader_priv) = BLSPubKey::generated_from_seed_indexed([0; 32], round);
+
+    let current_commit_signature = <BLSPubKey as SignatureKey>::sign(
+        &leader_priv,
+        builder_state_id.parent_commitment.as_ref(),
+    )
+    .unwrap();
+
+    // Simulate Consensus retries
+
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+
+        let available_blocks_result = proxy_global_state
+            .available_blocks(
+                &builder_state_id.parent_commitment,
+                builder_state_id.view.u64(),
+                leader_pub,
+                &current_commit_signature,
+            )
+            .await;
+
+        if available_blocks_result.is_ok() {
+            return (attempt, available_blocks_result);
+        }
+
+        if attempt >= TEST_NUM_CONSENSUS_RETRIES {
+            return (attempt, available_blocks_result);
+        }
+    }
+}
+
+/// [progress_round_with_available_block_info] is a helper function that
+/// progresses the round with the information returned from a call to
+/// [process_available_blocks_round]. This function simulates decide events
+/// if the next call to [ProxyGlobalState::available_blocks] returns something
+/// successfully rather than an error.
+///
+/// This is the workflow that happens if the builder has a block to propose,
+/// and the block is included by consensus.
+async fn progress_round_with_available_block_info(
+    proxy_global_state: &ProxyGlobalState<TestTypes>,
+    available_block_info: AvailableBlockInfo<TestTypes>,
+    builder_state_id: BuilderStateId<TestTypes>,
+    round: u64,
+    da_proposal_sender: &Sender<MessageType<TestTypes>>,
+    quorum_proposal_sender: &Sender<MessageType<TestTypes>>,
+) -> BuilderStateId<TestTypes> {
+    let (leader_pub, leader_priv) = BLSPubKey::generated_from_seed_indexed([0; 32], round);
+
+    let signed_parent_commitment =
+        <BLSPubKey as SignatureKey>::sign(&leader_priv, available_block_info.block_hash.as_ref())
+            .unwrap();
+
+    let claim_block_result = proxy_global_state
+        .claim_block(
+            &available_block_info.block_hash,
+            builder_state_id.view.u64(),
+            leader_pub,
+            &signed_parent_commitment,
+        )
+        .await
+        .unwrap_or_else(|_| panic!("claim block should succeed for round {round}"));
+
+    let _claim_block_header_result = proxy_global_state
+        .claim_block_header_input(
+            &available_block_info.block_hash,
+            builder_state_id.view.u64(),
+            leader_pub,
+            &signed_parent_commitment,
+        )
+        .await
+        .unwrap_or_else(|_| panic!("claim block header input should succeed for round {round}"));
+
+    progress_round_with_transactions(
+        builder_state_id,
+        claim_block_result.block_payload.transactions,
+        round,
+        da_proposal_sender,
+        quorum_proposal_sender,
+    )
+    .await
+}
+
+/// [progress_round_without_available_block_info] is a helper function that
+/// progresses the round without any available block information.
+///
+/// This is the workflow that happens if the builder does not have a block to
+/// propose, and consensus must continue to progress without a block built by
+/// any builder.
+async fn progress_round_without_available_block_info(
+    builder_state_id: BuilderStateId<TestTypes>,
+    round: u64,
+    da_proposal_sender: &Sender<MessageType<TestTypes>>,
+    quorum_proposal_sender: &Sender<MessageType<TestTypes>>,
+) -> BuilderStateId<TestTypes> {
+    progress_round_with_transactions(
+        builder_state_id,
+        vec![],
+        round,
+        da_proposal_sender,
+        quorum_proposal_sender,
+    )
+    .await
+}
+
+/// [progress_round_with_transactions] is a helper function that progress
+/// consensus with the given list of transactions.
+///
+/// This function is used by [progress_round_without_available_block_info] and
+/// by [progress_round_with_available_block_info] to progress the round with
+/// the given transactions.
+async fn progress_round_with_transactions(
+    builder_state_id: BuilderStateId<TestTypes>,
+    transactions: Vec<TestTransaction>,
+    round: u64,
+    da_proposal_sender: &Sender<MessageType<TestTypes>>,
+    quorum_proposal_sender: &Sender<MessageType<TestTypes>>,
+) -> BuilderStateId<TestTypes> {
+    let (leader_pub, leader_priv) = BLSPubKey::generated_from_seed_indexed([0; 32], round);
+    let encoded_transactions = TestTransaction::encode(&transactions);
+    let next_view = builder_state_id.view + 1;
+
+    // Create and send the DA Proposals and Quorum Proposals
+    {
+        let encoded_transactions_hash = Sha256::digest(&encoded_transactions);
+        let da_signature =
+        <TestTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey::sign(
+            &leader_priv,
+            &encoded_transactions_hash,
+        )
+        .expect("should sign encoded transactions hash successfully");
+
+        let metadata = TestMetadata {
+            num_transactions: transactions.len() as u64,
+        };
+
+        da_proposal_sender
+            .broadcast(MessageType::DaProposalMessage(DaProposalMessage {
+                proposal: Arc::new(Proposal {
+                    data: DaProposal::<TestTypes> {
+                        encoded_transactions: encoded_transactions.clone().into(),
+                        metadata,
+                        view_number: next_view,
+                    },
+                    signature: da_signature,
+                    _pd: Default::default(),
+                }),
+                sender: leader_pub,
+                total_nodes: TEST_NUM_NODES_IN_VID_COMPUTATION,
+            }))
+            .await
+            .expect("should broadcast DA Proposal successfully");
+
+        let payload_commitment =
+            vid_commitment(&encoded_transactions, TEST_NUM_NODES_IN_VID_COMPUTATION);
+
+        let (block_payload, metadata) =
+            <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
+                transactions,
+                &TestValidatedState::default(),
+                &TestInstanceState::default(),
+            )
+            .await
+            .unwrap();
+
+        let builder_commitment = <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(
+            &block_payload,
+            &metadata,
+        );
+
+        let block_header = TestBlockHeader {
+            block_number: round,
+            payload_commitment,
+            builder_commitment,
+            timestamp: round,
+            metadata,
+            random: 0,
+        };
+
+        let qc_proposal = QuorumProposal::<TestTypes> {
+            block_header,
+            view_number: next_view,
+            justify_qc: QuorumCertificate::<TestTypes>::genesis::<TestVersions>(
+                &TestValidatedState::default(),
+                &TestInstanceState::default(),
+            )
+            .await,
+            upgrade_certificate: None,
+            proposal_certificate: None,
+        };
+
+        let payload_vid_commitment =
+            <TestBlockHeader as BlockHeader<TestTypes>>::payload_commitment(
+                &qc_proposal.block_header,
+            );
+
+        let qc_signature = <TestTypes as hotshot_types::traits::node_implementation::NodeType>::SignatureKey::sign(
+                        &leader_priv,
+                        payload_vid_commitment.as_ref(),
+                        ).expect("Failed to sign payload commitment while preparing QC proposal");
+
+        quorum_proposal_sender
+            .broadcast(MessageType::QuorumProposalMessage(QuorumProposalMessage {
+                proposal: Arc::new(Proposal {
+                    data: qc_proposal.clone(),
+                    signature: qc_signature,
+                    _pd: Default::default(),
+                }),
+                sender: leader_pub,
+            }))
+            .await
+            .expect("should broadcast QC Proposal successfully");
+
+        BuilderStateId {
+            parent_commitment: payload_vid_commitment,
+            view: next_view,
+        }
+    }
+}
+
+/// [test_empty_block_rate] is a test to ensure that if we don't have any
+/// transactions being submitted, that the builder will continue it's current
+/// behavior of not proposing empty blocks.
+///
+/// |> Note: this test simulates how consensus interacts with the Builder in a
+/// |> very basic way.  When consensus asks for available blocks, and the
+/// |> Builder returns an error that indicates that it does not have any blocks
+/// |> to propose, consensus will retry a few times before giving up. As a
+/// |> result the number of times that consensus has to ask the Builder for
+/// |> block is an integral part of this test.
+#[async_std::test]
+async fn test_empty_block_rate() {
+    let (proxy_global_state, _, da_proposal_sender, quorum_proposal_sender, _) =
+        setup_builder_for_test(None);
+
+    let mut current_builder_state_id = BuilderStateId::<TestTypes> {
+        parent_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+        view: ViewNumber::genesis(),
+    };
+
+    for round in 0..10 {
+        let (attempts, available_available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, TEST_NUM_CONSENSUS_RETRIES,
+            "Consensus should retry {TEST_NUM_CONSENSUS_RETRIES} times to get available blocks"
+        );
+        assert!(available_available_blocks_result.is_err());
+
+        current_builder_state_id = progress_round_without_available_block_info(
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+}
+
+/// [test_eager_block_rate] is a test that ensures that the builder will propose
+/// empty blocks, if consensus indicates a proposal included transactions.
+///
+/// It checks initially that it does not propose any empty blocks in round 0.
+/// It checks that it proposes a block with transactions in round 1, which
+/// gets included by consensus.
+/// It then checks that the next `allow_empty_block_period` rounds return empty
+/// blocks without the need to retry.
+/// It then checks that the remaining round up to 9 will not propose any empty
+/// blocks.
+///
+/// |> Note: this test simulates how consensus interacts with the Builder in a
+/// |> very basic way.  When consensus asks for available blocks, and the
+/// |> Builder returns an error that indicates that it does not have any blocks
+/// |> to propose, consensus will retry a few times before giving up. As a
+/// |> result the number of times that consensus has to ask the Builder for
+/// |> block is an integral part of this test.
+#[async_std::test]
+async fn test_eager_block_rate() {
+    let allow_empty_block_period = 3;
+    let (proxy_global_state, _, da_proposal_sender, quorum_proposal_sender, _) =
+        setup_builder_for_test(Some(allow_empty_block_period));
+
+    let mut current_builder_state_id = BuilderStateId::<TestTypes> {
+        parent_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
+        view: ViewNumber::genesis(),
+    };
+
+    // Round 0
+    {
+        let round = 0;
+        let (attempts, available_available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, TEST_NUM_CONSENSUS_RETRIES,
+            "Consensus should retry {TEST_NUM_CONSENSUS_RETRIES} times to get available blocks for round {round}"
+        );
+
+        assert!(
+            available_available_blocks_result.is_err(),
+            "builder should not propose empty blocks for round {round}"
+        );
+
+        current_builder_state_id = progress_round_without_available_block_info(
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+
+    // Round 1, submit a single transaction, and advance the round
+    {
+        proxy_global_state
+            .submit_txns(vec![TestTransaction::new(vec![1])])
+            .await
+            .expect("should submit transaction without issue");
+
+        let round = 1;
+
+        let (attempts, available_available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, 1,
+            "Consensus should not have needed to retry at all for round {round}"
+        );
+
+        assert!(
+            available_available_blocks_result.is_ok(),
+            "builder should be proposing empty blocks for round {round}"
+        );
+
+        current_builder_state_id = progress_round_with_available_block_info(
+            &proxy_global_state,
+            available_available_blocks_result.unwrap()[0].clone(),
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+
+    // rounds 2 through 2 + allow_empty_block_period - 1 should propose empty
+    // blocks.
+    for round in 2..(2 + allow_empty_block_period) {
+        let (attempts, available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, 1,
+            "Consensus should not have needed to retry at all for round {round}"
+        );
+
+        assert!(
+            available_blocks_result.is_ok(),
+            "builder should be proposing empty blocks for round {round}"
+        );
+
+        let available_blocks_result = available_blocks_result.unwrap();
+
+        assert_eq!(
+            available_blocks_result[0].block_size, 0,
+            "the block should be empty for round {round}"
+        );
+
+        current_builder_state_id = progress_round_with_available_block_info(
+            &proxy_global_state,
+            available_blocks_result[0].clone(),
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+
+    // rounds 2 + allow_empty_block_period through 9 should not propose empty
+    for round in (2 + allow_empty_block_period)..10 {
+        let (attempts, available_blocks_result) = process_available_blocks_round(
+            &proxy_global_state,
+            current_builder_state_id.clone(),
+            round,
+        )
+        .await;
+
+        assert_eq!(
+            attempts, TEST_NUM_CONSENSUS_RETRIES,
+            "Consensus should have retries {TEST_NUM_CONSENSUS_RETRIES} times for round {round}"
+        );
+        assert!(available_blocks_result.is_err());
+
+        current_builder_state_id = progress_round_without_available_block_info(
+            current_builder_state_id,
+            round,
+            &da_proposal_sender,
+            &quorum_proposal_sender,
+        )
+        .await;
+    }
+}

--- a/crates/legacy/src/testing/finalization_test.rs
+++ b/crates/legacy/src/testing/finalization_test.rs
@@ -46,6 +46,10 @@ type TestSetup = (
 /// [TEST_NUM_NODES_IN_VID_COMPUTATION] controls the number of nodes that are
 /// used in the VID computation for the test.
 const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
+
+/// [TEST_NUM_CONSENSUS_RETRIES] controls the number of attempts that the
+/// simulated consensus will perform when an error is returned from the
+/// Builder when asking for available blocks.
 const TEST_NUM_CONSENSUS_RETRIES: usize = 4;
 
 /// [setup_builder_for_test] sets up a test environment for the builder state.

--- a/crates/legacy/src/testing/finalization_test.rs
+++ b/crates/legacy/src/testing/finalization_test.rs
@@ -43,6 +43,8 @@ type TestSetup = (
     async_broadcast::Sender<Arc<ReceivedTransaction<TestTypes>>>,
 );
 
+/// [TEST_NUM_NODES_IN_VID_COMPUTATION] controls the number of nodes that are
+/// used in the VID computation for the test.
 const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
 const TEST_NUM_CONSENSUS_RETRIES: usize = 4;
 

--- a/crates/legacy/src/testing/finalization_test.rs
+++ b/crates/legacy/src/testing/finalization_test.rs
@@ -52,12 +52,17 @@ const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
 /// Builder when asking for available blocks.
 const TEST_NUM_CONSENSUS_RETRIES: usize = 4;
 
+/// [TEST_CHANNEL_BUFFER_SIZE] governs the buffer size used for the test
+/// channels. All of the channels created need a capacity.  The specific
+/// capacity isn't specifically bounded, so it is set to an arbitrary value.
+const TEST_CHANNEL_BUFFER_SIZE: usize = 32;
+
 /// [setup_builder_for_test] sets up a test environment for the builder state.
 /// It returns a tuple containing the proxy global state, the sender for decide
 /// messages, the sender for data availability proposals,
 fn setup_builder_for_test(allow_empty_block_period: Option<u64>) -> TestSetup {
-    let (req_sender, req_receiver) = broadcast(32);
-    let (tx_sender, tx_receiver) = broadcast(32);
+    let (req_sender, req_receiver) = broadcast(TEST_CHANNEL_BUFFER_SIZE);
+    let (tx_sender, tx_receiver) = broadcast(TEST_CHANNEL_BUFFER_SIZE);
 
     let bootstrap_builder_state_id = BuilderStateId::<TestTypes> {
         parent_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),
@@ -81,9 +86,9 @@ fn setup_builder_for_test(allow_empty_block_period: Option<u64>) -> TestSetup {
         max_api_duration,
     );
 
-    let (decide_sender, decide_receiver) = broadcast(32);
-    let (da_proposal_sender, da_proposal_receiver) = broadcast(32);
-    let (quorum_proposal_sender, quorum_proposal_receiver) = broadcast(32);
+    let (decide_sender, decide_receiver) = broadcast(TEST_CHANNEL_BUFFER_SIZE);
+    let (da_proposal_sender, da_proposal_receiver) = broadcast(TEST_CHANNEL_BUFFER_SIZE);
+    let (quorum_proposal_sender, quorum_proposal_receiver) = broadcast(TEST_CHANNEL_BUFFER_SIZE);
     let bootstrap_builder_state = BuilderState::<TestTypes>::new(
         ParentBlockReferences {
             vid_commitment: vid_commitment(&[], TEST_NUM_NODES_IN_VID_COMPUTATION),


### PR DESCRIPTION
Closes #101
Closes #138 as an alternative
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Allows the builder to propose empty blocks for a period of time following the receipt of a proposal that indicates transactions have been proposed.

When the builder avoids proposing empty blocks it will slow down the progression of consensus.  For a better user experience it was determined that we should priortize proposing empty blocks following a view with proposed transactions in order to help speed up the finalization of previously submitted transactions.

A variable has been added to allow for the specification of a gracer period of views, that following a decide with transactions will build empty blocks if a block without transactions cannot be built.  This variable is configurable, and if set to `None` will default to 3.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
Attempt to change the empty block proposal behavior outside of the grace period.  When continually deciding empty blocks, the Builder should exhibit the behavior of not proposing empty blocks in an effort to not rapidly produce empty blocks.

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
