### PR TITLE
[Refactor] 1: Add builder state coordinator

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,2 @@
-disallowed-names = [ "TYPES" ]
-doc-valid-idents = [ "HotShot", ".." ]
+disallowed-names = ["TYPES"]
+doc-valid-idents = ["HotShot", ".."]

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ Cargo.lock
 /target*
 /.vscode
 
+mutants.out/
+mutants.out.old/
+
 # OSX
 **/.DS_Store
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4741,11 +4742,13 @@ name = "marketplace-builder-shared"
 version = "0.1.56"
 dependencies = [
  "anyhow",
+ "async-broadcast",
  "async-lock 3.4.0",
  "async-trait",
  "bincode",
  "chrono",
  "committable",
+ "derive_more 1.0.0",
  "either",
  "futures",
  "hex",
@@ -4753,8 +4756,11 @@ dependencies = [
  "hotshot-builder-api",
  "hotshot-events-service",
  "hotshot-example-types",
+ "hotshot-task-impls",
  "hotshot-testing",
  "hotshot-types",
+ "jf-vid",
+ "nonempty-collections",
  "portpicker",
  "rand 0.8.5",
  "serde",
@@ -5095,6 +5101,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty-collections"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07626f57b1cb0ee81e5193d331209751d2e18ffa3ceaa0fd6fab63db31fafd9"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,14 @@ clap = "4.5"
 chrono = { version = "0.4", features = ["serde"] }
 committable = "0.2"
 derivative = "2.2"
+derive_more = "1.0"
 either = "1.13"
 futures = "0.3"
+jf-vid = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
 hex = "0.4.3"
 lru = "0.12.5"
 multimap = "0.10.0"
+nonempty-collections = "0.2"
 num_cpus = "1.16"
 rand = "0.8"
 serde = "1.0"
@@ -38,6 +41,7 @@ tide-disco = "0.9"
 tokio = "1"
 toml = "0.8"
 tracing = "0.1"
+typenum = "1.17"
 url = "2.3"
 vbs = "0.1"
 vec1 = "1.12"
@@ -46,6 +50,9 @@ tracing-subscriber = "0.3"
 [workspace.package]
 version = "0.1.56"
 edition = "2021"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [workspace.lints.clippy]
 disallowed-names = "deny"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -3,16 +3,15 @@ name = "marketplace-builder-shared"
 version = { workspace = true }
 edition = { workspace = true }
 
-[features]
-testing = []
-
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
+async-broadcast = { workspace = true }
 async-lock = { workspace = true }
+async-trait = { workspace = true }
 bincode = { workspace = true }
 chrono = { workspace = true }
 committable = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 either = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
@@ -20,8 +19,11 @@ hotshot = { workspace = true }
 hotshot-builder-api = { workspace = true }
 hotshot-events-service = { workspace = true }
 hotshot-example-types = { workspace = true }
+hotshot-task-impls = { workspace = true }
 hotshot-testing = { workspace = true }
 hotshot-types = { workspace = true }
+jf-vid = { workspace = true }
+nonempty-collections = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 surf-disco = { workspace = true }

--- a/crates/shared/src/coordinator/builder_state_map.rs
+++ b/crates/shared/src/coordinator/builder_state_map.rs
@@ -1,0 +1,292 @@
+//! This module contains an optimizide implementation of a
+//! [`BuilderStateId`] to [`BuilderState`] map.
+
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    ops::RangeBounds,
+    sync::Arc,
+};
+
+use hotshot_types::{traits::node_implementation::NodeType, vid::VidCommitment};
+use nonempty_collections::{nem, NEMap};
+
+use crate::{block::BuilderStateId, state::BuilderState};
+
+/// A map from [`BuilderStateId`] to [`BuilderState`], implemented as a tiered map
+/// with the first tier being [`BTreeMap`] keyed by view number of [`BuilderStateId`]
+/// and the second [`NEMap`] keyed by VID commitment of [`BuilderStateId`].
+///
+/// Usage of [`BTreeMap`] means that the map has an convenient property of always being
+/// sorted by view number, which makes common operations such as pruning old views more efficient.
+///
+/// Second tier being non-empty by construction [`NEMap`] ensures that we can't accidentally
+/// create phantom entries with empty maps in the first tier.
+#[derive(Debug)]
+pub struct BuilderStateMap<Types: NodeType>(
+    BTreeMap<<Types as NodeType>::View, NEMap<VidCommitment, Arc<BuilderState<Types>>>>,
+);
+
+impl<Types: NodeType> BuilderStateMap<Types> {
+    /// Create a new empty map
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Returns an iterator visiting all values in this map
+    pub fn values(&self) -> impl Iterator<Item = &Arc<BuilderState<Types>>> {
+        self.0
+            .values()
+            .flat_map(|bucket| bucket.values().into_iter())
+    }
+
+    /// Returns a nested iterator visiting all [`BuilderState`]s for view numbers in given range
+    pub fn range<R>(
+        &self,
+        range: R,
+    ) -> impl Iterator<Item = impl Iterator<Item = &Arc<BuilderState<Types>>>>
+    where
+        R: RangeBounds<Types::View>,
+    {
+        self.0
+            .range(range)
+            .map(|(_, bucket)| bucket.values().into_iter())
+    }
+
+    /// Returns an iterator visiting all [`BuilderState`]s for given view number
+    pub fn bucket(
+        &self,
+        view_number: &Types::View,
+    ) -> impl Iterator<Item = &Arc<BuilderState<Types>>> {
+        self.0
+            .get(view_number)
+            .into_iter()
+            .flat_map(|bucket| bucket.values().into_iter())
+    }
+
+    /// Returns the number of builder states stored
+    pub fn len(&self) -> usize {
+        self.0.values().map(|bucket| bucket.len().get()).sum()
+    }
+
+    /// Returns whether this map is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.len() == 0
+    }
+
+    /// Get builder state by ID
+    pub fn get(&self, key: &BuilderStateId<Types>) -> Option<&Arc<BuilderState<Types>>> {
+        self.0.get(&key.parent_view)?.get(&key.parent_commitment)
+    }
+
+    /// Get highest view builder state
+    ///
+    /// Returns `None` if the map is empty
+    pub fn highest_view_builder(&self) -> Option<&Arc<BuilderState<Types>>> {
+        Some(&self.0.last_key_value()?.1.head_val)
+    }
+
+    /// Insert a new builder state
+    pub fn insert(&mut self, value: Arc<BuilderState<Types>>) {
+        let key = value.id();
+        match self.0.entry(key.parent_view) {
+            Entry::Vacant(entry) => {
+                entry.insert(nem![key.parent_commitment => value]);
+            }
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().insert(key.parent_commitment, value);
+            }
+        }
+    }
+
+    /// Returns highest view number for which we have a builder state
+    pub fn highest_view(&self) -> Option<Types::View> {
+        Some(*self.0.last_key_value()?.0)
+    }
+
+    /// Returns lowest view number for which we have a builder state
+    pub fn lowest_view(&self) -> Option<Types::View> {
+        Some(*self.0.first_key_value()?.0)
+    }
+
+    /// Removes every view lower than the `cutoff_view` (exclusive) from self and returns all removed views.
+    pub fn prune(&mut self, cutoff_view: Types::View) -> Self {
+        let high = self.0.split_off(&cutoff_view);
+        let low = std::mem::replace(&mut self.0, high);
+        Self(low)
+    }
+}
+
+impl<Types: NodeType> Default for BuilderStateMap<Types> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cmp::Ordering, ops::Bound};
+
+    use crate::testing::mock;
+
+    use super::*;
+    use hotshot_example_types::node_types::TestTypes;
+    use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
+    use rand::{distributions::Standard, thread_rng, Rng};
+
+    type View = ViewNumber;
+    type BuilderStateMap = super::BuilderStateMap<TestTypes>;
+
+    #[test]
+    fn test_new_map() {
+        let new_map = BuilderStateMap::new();
+        assert!(new_map.is_empty());
+        assert_eq!(new_map.len(), 0);
+
+        let default_map = BuilderStateMap::default();
+        assert!(default_map.is_empty());
+        assert_eq!(default_map.len(), 0);
+    }
+
+    #[test]
+    fn test_insert_and_get() {
+        let mut map = BuilderStateMap::new();
+
+        let builder_state = mock::builder_state(1);
+        let state_id = builder_state.id();
+
+        map.insert(builder_state.clone());
+
+        assert!(!map.is_empty());
+        assert_eq!(map.len(), 1);
+        assert!(Arc::ptr_eq(map.get(&state_id).unwrap(), &builder_state));
+    }
+
+    #[test]
+    fn test_range_iteration() {
+        let mut map = BuilderStateMap::new();
+
+        for i in 0..5 {
+            map.insert(mock::builder_state(i));
+        }
+
+        let start = View::new(1);
+        let end = View::new(3);
+
+        let collected: Vec<_> = map
+            .range((Bound::Included(start), Bound::Excluded(end)))
+            .flatten()
+            .collect();
+
+        assert_eq!(collected.len(), 2);
+        assert_eq!(*collected[0].parent_block_references.view_number, 1);
+        assert_eq!(*collected[1].parent_block_references.view_number, 2);
+    }
+
+    #[test]
+    fn test_pruning() {
+        let view_count = 11;
+        let states_per_view = 13;
+        let cutoff = 7;
+
+        let mut map = BuilderStateMap::new();
+
+        for view in 0..view_count {
+            for _ in 0..states_per_view {
+                map.insert(mock::builder_state(view));
+            }
+        }
+
+        let pruned_map = map.prune(View::new(cutoff));
+        assert_eq!(pruned_map.len() as u64, cutoff * states_per_view);
+        assert_eq!(map.len() as u64, (view_count - cutoff) * states_per_view);
+
+        assert!(pruned_map.bucket(&View::new(cutoff - 1)).next().is_some());
+        assert!(map.bucket(&View::new(cutoff)).next().is_some());
+
+        assert!(pruned_map.bucket(&View::new(cutoff)).next().is_none());
+        assert!(map.bucket(&View::new(cutoff - 1)).next().is_none());
+    }
+
+    #[test]
+    fn test_highest_and_lowest_view() {
+        let mut map = BuilderStateMap::new();
+        assert_eq!(map.highest_view(), None);
+        assert_eq!(map.lowest_view(), None);
+
+        for i in 3..13 {
+            map.insert(mock::builder_state(i));
+        }
+
+        assert_eq!(*map.highest_view().unwrap(), 12);
+        assert_eq!(*map.lowest_view().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_highest_view_builder() {
+        let mut map = BuilderStateMap::new();
+        assert!(map.highest_view_builder().is_none());
+
+        let mut states: Vec<_> = thread_rng()
+            .sample_iter(Standard)
+            .take(100)
+            .map(mock::builder_state)
+            .collect();
+
+        for state in states.iter() {
+            map.insert(state.clone());
+        }
+
+        states.sort_by(|a, b| {
+            a.parent_block_references
+                .view_number
+                .cmp(&b.parent_block_references.view_number)
+        });
+
+        assert_eq!(
+            map.highest_view_builder()
+                .unwrap()
+                .parent_block_references
+                .view_number,
+            states.last().unwrap().parent_block_references.view_number
+        );
+    }
+
+    #[test]
+    fn test_iterator() {
+        let mut map = BuilderStateMap::new();
+
+        let mut states: Vec<_> = thread_rng()
+            .sample_iter(Standard)
+            .take(100)
+            .map(mock::builder_state)
+            .collect();
+        assert_eq!(states.len(), 100);
+
+        for state in states.iter() {
+            map.insert(state.clone());
+        }
+
+        states.sort_by(compare_builders);
+
+        let mut map_states = map.values().cloned().collect::<Vec<_>>();
+        map_states.sort_by(compare_builders);
+
+        for (original_state, map_state) in states.into_iter().zip(map_states) {
+            assert!(Arc::ptr_eq(&original_state, &map_state));
+        }
+    }
+
+    fn compare_builders(
+        a: &Arc<BuilderState<TestTypes>>,
+        b: &Arc<BuilderState<TestTypes>>,
+    ) -> Ordering {
+        a.parent_block_references
+            .view_number
+            .cmp(&b.parent_block_references.view_number)
+            .then(
+                a.parent_block_references
+                    .vid_commitment
+                    .cmp(&b.parent_block_references.vid_commitment),
+            )
+    }
+}

--- a/crates/shared/src/coordinator/mod.rs
+++ b/crates/shared/src/coordinator/mod.rs
@@ -1,0 +1,683 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    ops::Bound,
+    sync::Arc,
+    time::Duration,
+};
+
+use async_broadcast::Sender;
+use async_lock::{Mutex, RwLock};
+use builder_state_map::BuilderStateMap;
+use either::Either;
+use hotshot_builder_api::v0_3::builder::BuildError;
+use hotshot_types::{
+    data::{DaProposal, QuorumProposal},
+    event::LeafInfo,
+    traits::{
+        block_contents::BlockHeader,
+        node_implementation::{ConsensusTime, NodeType},
+    },
+};
+use tracing::{error, info, warn};
+
+use crate::{
+    block::{BuilderStateId, ParentBlockReferences, ReceivedTransaction},
+    state::BuilderState,
+    utils::ProposalId,
+};
+
+pub mod builder_state_map;
+
+type ProposalMap<Types> =
+    HashMap<ProposalId<Types>, Either<QuorumProposal<Types>, DaProposal<Types>>>;
+
+/// Result of looking up a builder state by ID.
+///
+/// Different from an [`Option`] as it distinguishes between
+/// two cases: one where the [`BuilderStateId`] is for a view that has
+/// already been marked as decided - meaning there's no way
+/// it will exist again - and another where the [`BuilderStateId`] is
+/// for a not yet decided view, indicating a chance that
+/// this entry may be populated at some point in the future.
+#[derive(Clone, Debug)]
+pub enum BuilderStateLookup<Types>
+where
+    Types: NodeType,
+{
+    /// Corresponding [`BuilderState`] doesn't exist
+    NotFound,
+    /// The view number looked up was already decided
+    Decided,
+    /// Successful lookup
+    Found(Arc<BuilderState<Types>>),
+}
+
+/// A coordinator managing the lifecycle of [`BuilderState`]s.
+///
+/// Its responsibilities include:
+/// - Storing builder states and allowing their lookup
+/// - Spawning new builder states
+/// - Distributing transactions to builder states through a broadcast channel
+/// - Removing outdated builder states
+///
+/// <div class="warning">
+///
+///   Important: [`BuilderState`]s do not automatically remove transactions from the channel.
+///   Refer to [`BuilderState::collect_txns`] for more details on manually dequeuing transactions.
+///
+/// </div>
+///
+/// For the coordinator to function correctly, the following handler functions
+/// must be invoked when receiving corresponding HotShot events:
+/// - [`Self::handle_decide`]
+/// - [`Self::handle_quorum_proposal`]
+/// - [`Self::handle_da_proposal`]
+/// - [`Self::handle_transaction`]
+pub struct BuilderStateCoordinator<Types>
+where
+    Types: NodeType,
+{
+    builder_states: RwLock<BuilderStateMap<Types>>,
+    transaction_sender: Sender<Arc<ReceivedTransaction<Types>>>,
+    proposals: Mutex<ProposalMap<Types>>,
+}
+
+impl<Types> BuilderStateCoordinator<Types>
+where
+    Types: NodeType,
+{
+    /// Constructs a new [`BuilderState`] coordinator.
+    /// `txn_channel_capacity` controls the size of the channel used to distribute transactions to [`BuilderState`]s.
+    /// `txn_garbage_collect_duration` specifies the duration for which the coordinator retains the hashes of transactions
+    /// that have been marked as included by its [`BuilderState`]s. Once this duration has elapsed, new [`BuilderState`]s
+    /// can include duplicates of older transactions should such be received again.
+    pub fn new(txn_channel_capacity: usize, txn_garbage_collect_duration: Duration) -> Self {
+        let (txn_sender, txn_receiver) = async_broadcast::broadcast(txn_channel_capacity);
+        let bootstrap_state = BuilderState::new(
+            ParentBlockReferences::bootstrap(),
+            txn_garbage_collect_duration,
+            txn_receiver,
+            Types::ValidatedState::default(),
+        );
+        let mut builder_states = BuilderStateMap::new();
+        builder_states.insert(bootstrap_state);
+
+        Self {
+            transaction_sender: txn_sender,
+            builder_states: RwLock::new(builder_states),
+            proposals: Mutex::new(ProposalMap::new()),
+        }
+    }
+
+    /// This function should be called whenever new decide events are received from HotShot.
+    /// Its main responsibility is to perform garbage collection of [`BuilderState`]s for older views.
+    /// The function returns the [`BuilderState`]s that have been garbage collected.
+    #[tracing::instrument(skip_all)]
+    pub async fn handle_decide(
+        &self,
+        leaf_chain: Arc<Vec<LeafInfo<Types>>>,
+    ) -> BuilderStateMap<Types> {
+        let latest_decide_view_num = leaf_chain[0].leaf.view_number();
+        let mut builder_states = self.builder_states.write().await;
+        let highest_active_view_num = builder_states
+            .highest_view()
+            .unwrap_or(Types::View::genesis());
+        let cutoff = Types::View::new(*latest_decide_view_num.min(highest_active_view_num));
+        builder_states.prune(cutoff)
+    }
+
+    /// This function should be called whenever new transactions are received from HotShot.
+    /// <div class="warning">
+    ///
+    ///   Important: [`BuilderState`]s do not automatically remove transactions from the channel.
+    ///   Refer to [`BuilderState::collect_txns`] for more details on manually dequeuing transactions.
+    ///
+    /// </div>
+    #[tracing::instrument(skip_all, fields(transaction = %transaction.commit))]
+    #[must_use]
+    pub async fn handle_transaction(
+        &self,
+        transaction: ReceivedTransaction<Types>,
+    ) -> Result<(), BuildError> {
+        match self.transaction_sender.try_broadcast(Arc::new(transaction)) {
+            Ok(None) => Ok(()),
+            Ok(Some(evicted_txn)) => {
+                warn!(
+                    ?evicted_txn.commit,
+                    "Overflow mode enabled, transaction evicted",
+                );
+                Ok(())
+            }
+            Err(err) => {
+                warn!(?err, "Failed to broadcast txn");
+                Err(BuildError::Error(err.to_string()))
+            }
+        }
+    }
+
+    /// This function should be called whenever new DA Proposal is recieved from HotShot.
+    /// Coordinator uses matching Quorum and DA proposals to track creation of new blocks
+    /// and spawning corresponding builder states for those.
+    pub async fn handle_da_proposal(&self, da_proposal: DaProposal<Types>) {
+        let proposal_id = ProposalId::from_da_proposal(&da_proposal);
+        self.handle_proposal(proposal_id, Either::Right(da_proposal))
+            .await;
+    }
+
+    /// This function should be called whenever new Quorum Proposal is recieved from HotShot.
+    /// Coordinator uses matching Quorum and DA proposals to track creation of new blocks
+    /// and spawning corresponding builder states for those.
+    pub async fn handle_quorum_proposal(&self, quorum_proposal: QuorumProposal<Types>) {
+        let proposal_id = ProposalId::from_quorum_proposal(&quorum_proposal);
+        self.handle_proposal(proposal_id, Either::Left(quorum_proposal))
+            .await;
+    }
+
+    /// Generalized function to handle Quorum and DA proposals. The behavior is as follows:
+    ///
+    /// - If a matching proposal of the other kind exists for this [`ProposalId`], remove it
+    ///   from storage and spawn a new [`BuilderState`] from the resulting proposal pair.
+    /// - If a proposal of the same kind is stored, do nothing.
+    /// - If there are no records for this [`ProposalId`], store it.
+    #[tracing::instrument(skip_all)]
+    async fn handle_proposal(
+        &self,
+        proposal_id: ProposalId<Types>,
+        proposal: Either<QuorumProposal<Types>, DaProposal<Types>>,
+    ) {
+        match self.proposals.lock().await.entry(proposal_id) {
+            Entry::Occupied(entry) => {
+                if entry.get().is_left() == proposal.is_left() {
+                    // Duplicate proposal, ignore.
+                    return;
+                }
+
+                match (entry.remove(), proposal) {
+                    (Either::Right(da_proposal), Either::Left(quorum_proposal))
+                    | (Either::Left(quorum_proposal), Either::Right(da_proposal)) => {
+                        self.spawn_builder_state(quorum_proposal, da_proposal).await
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(proposal);
+            }
+        }
+    }
+
+    /// Get the lowest view we have stored
+    pub async fn lowest_view(&self) -> Types::View {
+        self.builder_states
+            .read()
+            .await
+            .lowest_view()
+            .unwrap_or(Types::View::genesis())
+    }
+
+    /// Looks up a [`BuilderState`] by id.
+    ///
+    /// Refer to [`BuilderStateLookup`] for more information on return value
+    #[tracing::instrument(skip_all)]
+    #[must_use]
+    pub async fn lookup_builder_state(
+        &self,
+        id: &BuilderStateId<Types>,
+    ) -> BuilderStateLookup<Types> {
+        if let Some(entry) = self.builder_states.read().await.get(id).cloned() {
+            return BuilderStateLookup::Found(entry);
+        }
+
+        if self.lowest_view().await > id.parent_view {
+            return BuilderStateLookup::Decided;
+        }
+
+        BuilderStateLookup::NotFound
+    }
+
+    /// Looks up the builder state with the highest view number.
+    /// If there are no builder states at all, returns [`None`].
+    #[tracing::instrument(skip_all)]
+    #[must_use]
+    pub async fn highest_view_builder(&self) -> Option<Arc<BuilderState<Types>>> {
+        self.builder_states
+            .read()
+            .await
+            .highest_view_builder()
+            .cloned()
+    }
+
+    /// Spawn a new builder state off of matching pair of Quorum and DA proposals, store it in [`Self::builder_states`]
+    async fn spawn_builder_state(
+        &self,
+        quorum_proposal: QuorumProposal<Types>,
+        da_proposal: DaProposal<Types>,
+    ) {
+        assert_eq!(quorum_proposal.view_number, da_proposal.view_number);
+
+        let mut candidate_parents = self.find_builder_states_to_extend(&quorum_proposal).await;
+
+        if candidate_parents.is_empty() {
+            error!(
+                ?quorum_proposal,
+                ?da_proposal,
+                "Couldn't find a parent for new builder state"
+            );
+        }
+
+        if candidate_parents.len() > 1 {
+            info!(
+                ?candidate_parents,
+                "Multiple candidates for new builder state parent"
+            );
+        }
+
+        // if we have multiple candidate states, this is the simplest way to choose one
+        let Some(parent_state) = candidate_parents.pop() else {
+            return;
+        };
+
+        let child_state = parent_state
+            .new_child(quorum_proposal.clone(), da_proposal.clone())
+            .await;
+
+        self.builder_states.write().await.insert(child_state);
+    }
+
+    /// This is an utility function that is used to determine which [`BuilderState`]s
+    /// are the best fit to extend from for given [`QuorumProposal`]
+    ///
+    /// In an ideal circumstance the best [`BuilderState`] to extend from is going to
+    /// be the one that is immediately preceding the [`QuorumProposal`] that we are
+    /// attempting to extend from. However, if all we know is the view number of
+    /// the [`QuorumProposal`] that we are attempting to extend from, then we may end
+    /// up in a scenario where we have multiple [`BuilderState`]s that are all equally
+    /// valid to extend from.  When this happens, we have the potential for a data
+    /// race.
+    ///
+    /// The primary cause of this has to due with the interface of the
+    /// [`BuilderStateCoordinator`]'s API.  In general, we want to be able to retrieve
+    /// a [`BuilderState`] via the [`BuilderStateId`]. The [`BuilderStateId`] only references
+    /// a [`ViewNumber`](hotshot_types::data::ViewNumber) and a [`VidCommitment`](`hotshot_types::vid::VidCommitment`).
+    /// While this information is available in the [`QuorumProposal`],
+    /// it only helps us to rule out [`BuilderState`]s that already exist.
+    /// It does **NOT** help us to pick a [`BuilderState`] that is the best fit to extend from.
+    ///
+    /// This is where the `justify_qc` comes in to consideration.  The `justify_qc`
+    /// contains the previous [`ViewNumber`](hotshot_types::data::ViewNumber) that is
+    /// being extended from, and in addition it also contains the previous
+    /// [`Commitment<Leaf<Types>>`](`committable::Commitment`)
+    /// that is being built on top of.  Since our [`BuilderState`]s store identifying
+    /// information that contains this same `leaf_commit` we can compare these
+    /// directly to ensure that we are extending from the correct [`BuilderState`].
+    ///
+    /// This function determines the best [`BuilderState`] in the following steps:
+    ///
+    /// 1. If we have a [`BuilderState`] that is already spawned for the current
+    ///    [`QuorumProposal`], then we should should return no states, as one already
+    ///    exists.  This will prevent us from attempting to spawn duplicate
+    ///    [`BuilderState`]s.
+    /// 2. Attempt to find all [`BuilderState`]s that are recorded within
+    ///    coordinator that have matching view number and leaf commitments. There
+    ///    *should* only be one of these.  But all would be valid extension points.
+    /// 3. If we can't find any [`BuilderState`]s that match the view number
+    ///    and leaf commitment, then we should return for the maximum stored view
+    ///    number that is smaller than the current [`QuorumProposal`].
+    /// 4. If there is is only one [`BuilderState`] stored in the coordinator, then
+    ///    we should return that [`BuilderState`] as the best fit.
+    /// 5. If none of the other criteria match, we return an empty result as it is
+    ///    unclear what to do in this case.
+    ///
+    /// <div class="warning">
+    ///
+    ///  Note: Any time this function returns more than a single entry in its
+    ///  result, there is a potential for a race condition.  This is
+    ///  because there are multiple [`BuilderState`]s that are equally valid to
+    ///  extend from.  This race could be avoided by just picking one of the
+    ///  entries in the resulting [`Vec`], but this is not done here in order
+    ///  to allow us to highlight the possibility of the race.
+    ///
+    /// </div>
+    #[must_use]
+    async fn find_builder_states_to_extend(
+        &self,
+        quorum_proposal: &QuorumProposal<Types>,
+    ) -> Vec<Arc<BuilderState<Types>>> {
+        // This is ID of the state we want to spawn
+        let current_builder_state_id = BuilderStateId {
+            parent_view: quorum_proposal.view_number,
+            parent_commitment: quorum_proposal.block_header.payload_commitment(),
+        };
+
+        let builder_states = self.builder_states.read().await;
+
+        // The first step is to check if we already have a spawned [BuilderState].
+        // If we do, then we should indicate that there is no best fit, as we
+        // don't want to spawn another [BuilderState].
+        if builder_states.get(&current_builder_state_id).is_some() {
+            // We already have a spawned [BuilderState] for this proposal.
+            // So we should just ignore it.
+            return Vec::new();
+        }
+
+        // Next we want to see if there is an immediate match for a [BuilderState]
+        // that we can extend from.  This is the most ideal situation, as it
+        // implies that we are extending from the correct [BuilderState].
+        // We do this by checking the `justify_qc` stored within the
+        // [QuorumProposal], and checking it against the current spawned
+        // [BuilderState]s
+        let justify_qc = &quorum_proposal.justify_qc;
+
+        let existing_states = builder_states
+            .bucket(&justify_qc.view_number)
+            .filter(|state| {
+                state.parent_block_references.leaf_commit == justify_qc.data.leaf_commit
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        // If we found any matching [BuilderState]s, then we should return them
+        // as the best fit.
+        if !existing_states.is_empty() {
+            return existing_states;
+        }
+
+        warn!("No ideal match for builder state to extend");
+
+        // At this point, we don't have any "ideal" matches or scenarios.  So we
+        // need to look for a suitable fall-back. The best fallback condition to
+        // start with is any [BuilderState] that has the maximum spawned view
+        // number whose value is smaller than the current [QuorumProposal].
+        if let Some(states) = builder_states
+            .range((
+                Bound::Unbounded,
+                Bound::Excluded(current_builder_state_id.parent_view),
+            ))
+            .next()
+        {
+            // If we have a maximum view number that meets our criteria, then we should
+            // return all [BuilderStateId]s that match this view number.
+            // This can lead to multiple [BuilderStateId]s being returned.
+            // If we are the maximum stored view number smaller than the quorum
+            // proposal's view number, then we are the best fit.
+            return states.cloned().collect();
+        }
+
+        // This is our last ditch effort to continue making progress.  If there is
+        // only one [BuilderState] active, then we should return that as the best
+        // fit, as it will be the only way we can continue making progress with
+        // the builder.
+        if builder_states.len() == 1 {
+            return builder_states
+                .highest_view_builder()
+                .cloned()
+                .into_iter()
+                .collect();
+        }
+        drop(builder_states);
+
+        // This implies that there are only larger [BuilderState]s active than
+        // the one we are.  This is weird, it implies that some sort of time
+        // travel has occurred view-wise.  It is unclear what to do in this
+        // situation.
+        warn!("View time-travel");
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use hotshot_example_types::node_types::TestTypes;
+
+    use crate::{
+        block::TransactionSource,
+        testing::{
+            constants::{TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD},
+            mock,
+        },
+    };
+
+    use super::*;
+
+    type BuilderStateCoordinator = super::BuilderStateCoordinator<TestTypes>;
+
+    #[tokio::test]
+    async fn test_coordinator_new() {
+        let coordinator =
+            BuilderStateCoordinator::new(TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD);
+
+        assert_eq!(
+            coordinator.builder_states.read().await.len(),
+            1,
+            "The coordinator should be populated with a bootstrap builder state."
+        );
+
+        assert_eq!(
+            coordinator
+                .builder_states
+                .read()
+                .await
+                .highest_view_builder()
+                .unwrap()
+                .parent_block_references,
+            ParentBlockReferences::bootstrap(),
+            "The coordinator should be populated with a bootstrap builder state."
+        );
+
+        assert!(
+            coordinator.proposals.lock().await.is_empty(),
+            "The coordinator should not have any proposals stored."
+        );
+
+        assert_eq!(
+            coordinator.transaction_sender.capacity(),
+            TEST_CHANNEL_BUFFER_SIZE,
+            "The coordinator TX channel should have the capacity passed to new.",
+        );
+
+        assert_eq!(
+            coordinator
+                .builder_states
+                .read()
+                .await
+                .highest_view_builder()
+                .unwrap()
+                .included_txns
+                .period,
+            TEST_INCLUDED_TX_GC_PERIOD,
+            "Coordinator-created builder states should have the GC period passed to new.",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_proposal_matching_types_creates_builder_state() {
+        let coordinator =
+            BuilderStateCoordinator::new(TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD);
+
+        let (da_proposal, quorum_proposal) = mock::proposals(7).await;
+
+        // First, insert a DA proposal into the coordinator
+        coordinator.handle_da_proposal(da_proposal).await;
+
+        // Now, insert a matching quorum proposal
+        coordinator.handle_quorum_proposal(quorum_proposal).await;
+
+        // Verify that a new BuilderState has been created
+        let builder_states = coordinator.builder_states.read().await;
+        assert_eq!(
+            builder_states.len(),
+            2,
+            "The coordinator should have 2 builder states: one bootstrap and one created from matching proposals."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_proposal_duplicate_proposal_ignored() {
+        let coordinator =
+            BuilderStateCoordinator::new(TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD);
+
+        let (proposal, _) = mock::proposals(7).await;
+
+        // Insert the same DA proposal twice
+        coordinator.handle_da_proposal(proposal.clone()).await;
+        coordinator.handle_da_proposal(proposal).await;
+
+        // Check that only one proposal exists in the storage
+        let proposals = coordinator.proposals.lock().await;
+        assert_eq!(
+            proposals.len(),
+            1,
+            "There should be exactly one DA proposal stored, duplicates should be ignored."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_proposal_stores_new_proposal_when_no_match() {
+        let coordinator =
+            BuilderStateCoordinator::new(TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD);
+
+        let (proposal, _) = mock::proposals(1).await;
+        let proposal_id = ProposalId::from_da_proposal(&proposal);
+
+        // Insert a new DA proposal
+        coordinator.handle_da_proposal(proposal).await;
+
+        // Verify it's stored in proposals
+        let proposals = coordinator.proposals.lock().await;
+        assert_eq!(
+            proposals.len(),
+            1,
+            "The proposals map should contain one proposal after adding a new DA proposal."
+        );
+        assert!(
+            proposals.contains_key(&proposal_id),
+            "The proposals map should contain the inserted DA proposal."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_proposal_same_view_different_proposals() {
+        let coordinator =
+            BuilderStateCoordinator::new(TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD);
+
+        let view_number = 9; // arbitrary
+        let (da_proposal_1, quorum_proposal_1) = mock::proposals(view_number).await;
+        let (da_proposal_2, quorum_proposal_2) = mock::proposals(view_number).await;
+
+        // First, insert a DA proposal into the coordinator
+        coordinator.handle_da_proposal(da_proposal_1).await;
+
+        // Now, insert a quorum proposal with matching view but different payload
+        coordinator.handle_quorum_proposal(quorum_proposal_2).await;
+
+        // Verify that no new builder states has been created
+        assert_eq!(
+            coordinator.builder_states.read().await.len(),
+            1,
+            "The coordinator should have 2 builder states: one bootstrap and one created from matching proposals."
+        );
+
+        // Complete both proposal sets
+        coordinator.handle_quorum_proposal(quorum_proposal_1).await;
+        coordinator.handle_da_proposal(da_proposal_2).await;
+
+        // Verify that inserting matching proposals spawns both new builder states
+        assert_eq!(
+            coordinator.builder_states.read().await.len(),
+            3,
+            "The coordinator should have 2 builder states: one bootstrap and one created from matching proposals."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decide_reaps_old_proposals() {
+        let coordinator =
+            BuilderStateCoordinator::new(TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD);
+
+        for view in 0..100 {
+            let (da_proposal, quorum_proposal) = mock::proposals(view).await;
+            coordinator.handle_quorum_proposal(quorum_proposal).await;
+            coordinator.handle_da_proposal(da_proposal).await;
+        }
+
+        // Verify that inserting matching proposals spawn new builder states
+        assert_eq!(
+            coordinator.builder_states.read().await.len() as u64,
+            101,
+            "The coordinator should have 101 builder states: one bootstrap and one created from each pair of proposals"
+        );
+
+        coordinator
+            .handle_decide(mock::decide_leaf_chain(97).await)
+            .await;
+
+        // Verify that after decide event we have only proposals for views 97, 98 and 99 left
+        assert_eq!(
+            coordinator.builder_states.read().await.len() as u64,
+            3,
+            "The coordinator should have 2 builder states left after pruning"
+        );
+
+        coordinator
+            .handle_decide(mock::decide_leaf_chain(u64::MAX).await)
+            .await;
+
+        // Verify that decides do not prune the last remaining view
+        assert_eq!(
+            coordinator.builder_states.read().await.len() as u64,
+            1,
+            "The coordinator should have 2 builder states left after pruning"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transaction_overflow() {
+        let coordinator =
+            BuilderStateCoordinator::new(TEST_CHANNEL_BUFFER_SIZE, TEST_INCLUDED_TX_GC_PERIOD);
+
+        // Coordinator should handle transactions while there's space in the buffer
+        for _ in 0..TEST_CHANNEL_BUFFER_SIZE {
+            coordinator
+                .handle_transaction(ReceivedTransaction::new(
+                    mock::transaction(),
+                    TransactionSource::Public,
+                ))
+                .await
+                .unwrap();
+        }
+
+        // Coordinator should return an error when the channel overflows
+        coordinator
+            .handle_transaction(ReceivedTransaction::new(
+                mock::transaction(),
+                TransactionSource::Public,
+            ))
+            .await
+            .unwrap_err();
+
+        // Clear the channel
+        coordinator
+            .builder_states
+            .read()
+            .await
+            .highest_view_builder()
+            .unwrap()
+            .collect_txns(Instant::now() + Duration::from_millis(100))
+            .await;
+
+        // After clearing the channel, coordinator should handle transactions again
+        for _ in 0..TEST_CHANNEL_BUFFER_SIZE {
+            coordinator
+                .handle_transaction(ReceivedTransaction::new(
+                    mock::transaction(),
+                    TransactionSource::Public,
+                ))
+                .await
+                .unwrap();
+        }
+    }
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 pub mod block;
+pub mod coordinator;
+pub mod state;
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub mod testing;
 pub mod utils;

--- a/crates/shared/src/state.rs
+++ b/crates/shared/src/state.rs
@@ -1,0 +1,220 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    block::{BuilderStateId, ParentBlockReferences, ReceivedTransaction},
+    utils::RotatingSet,
+};
+use async_broadcast::Receiver;
+use async_lock::{Mutex, RwLock};
+use committable::{Commitment, Committable};
+use hotshot::traits::{BlockPayload, ValidatedState};
+use hotshot_types::{
+    data::{DaProposal, Leaf, QuorumProposal},
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
+};
+
+#[derive(derive_more::Debug, Clone)]
+pub struct TransactionQueue<Types>
+where
+    Types: NodeType,
+{
+    /// Commits of transactions currently in the [`Self::transactions`].  This is used as a quick
+    /// check for whether a transaction is already in the [`Self::transactions`] queue or not.
+    ///
+    /// This should be kept up-to-date with the queue as it acts as an
+    /// accessory to it.
+    commits: HashSet<Commitment<Types::Transaction>>,
+
+    /// Queue of available transactions
+    #[debug(skip)]
+    transactions: VecDeque<Arc<ReceivedTransaction<Types>>>,
+}
+
+impl<Types> Default for TransactionQueue<Types>
+where
+    Types: NodeType,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Types> TransactionQueue<Types>
+where
+    Types: NodeType,
+{
+    pub fn new() -> Self {
+        Self {
+            commits: HashSet::new(),
+            transactions: VecDeque::new(),
+        }
+    }
+
+    pub fn prune<'a>(&mut self, commits: impl Iterator<Item = &'a Commitment<Types::Transaction>>) {
+        for commit in commits {
+            self.commits.remove(commit);
+        }
+        self.transactions
+            .retain(|txn| self.commits.contains(&txn.commit));
+    }
+
+    pub fn insert(&mut self, transaction: Arc<ReceivedTransaction<Types>>) -> bool {
+        if !self.commits.contains(&transaction.commit) {
+            self.commits.insert(transaction.commit);
+            self.transactions.push_back(transaction);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn pop_front(&mut self) -> Option<Arc<ReceivedTransaction<Types>>> {
+        let transaction = self.transactions.pop_front()?;
+        self.commits.remove(&transaction.commit);
+        Some(transaction)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.commits.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Arc<ReceivedTransaction<Types>>> {
+        self.transactions.iter()
+    }
+}
+
+#[derive(derive_more::Debug)]
+pub struct BuilderState<Types: NodeType> {
+    /// Spawned-from references to the parent block.
+    pub parent_block_references: ParentBlockReferences<Types>,
+
+    /// Transactions that have been included in recent blocks that have
+    /// been built. This is used to guarantee that a transaction is
+    /// not duplicated.
+    /// Maintains a history of at least the last 3 proposals or more, depending
+    /// on the [`RotatingSet`]'s rotation period, because the set is updated and
+    /// [`RotatingSet::rotate`] is only called when spawning a new builder
+    /// state and may not discard older proposals if insufficient time has passed
+    /// since the previous rotation.
+    #[debug(skip)]
+    pub included_txns: RotatingSet<Commitment<Types::Transaction>>,
+
+    /// Queue of transactions that are not yet included from the viewpoint
+    /// of this [`BuilderState`]
+    pub txn_queue: RwLock<TransactionQueue<Types>>,
+
+    #[debug(skip)]
+    pub txn_receiver: Mutex<Receiver<Arc<ReceivedTransaction<Types>>>>,
+
+    #[debug(skip)]
+    pub validated_state: Types::ValidatedState,
+}
+
+impl<Types> BuilderState<Types>
+where
+    Types: NodeType,
+{
+    pub fn new(
+        parent: ParentBlockReferences<Types>,
+        txn_garbage_collect_duration: Duration,
+        txn_receiver: Receiver<Arc<ReceivedTransaction<Types>>>,
+        validated_state: Types::ValidatedState,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            parent_block_references: parent,
+            included_txns: RotatingSet::new(txn_garbage_collect_duration),
+            txn_queue: RwLock::new(TransactionQueue::new()),
+            txn_receiver: Mutex::new(txn_receiver),
+            validated_state,
+        })
+    }
+
+    pub fn id(&self) -> BuilderStateId<Types> {
+        BuilderStateId {
+            parent_view: self.parent_block_references.view_number,
+            parent_commitment: self.parent_block_references.vid_commitment,
+        }
+    }
+
+    pub(crate) async fn new_child(
+        self: Arc<Self>,
+        quorum_proposal: QuorumProposal<Types>,
+        da_proposal: DaProposal<Types>,
+    ) -> Arc<Self> {
+        let leaf = Leaf::from_quorum_proposal(&quorum_proposal);
+
+        let validated_state = Types::ValidatedState::from_header(leaf.block_header());
+
+        let mut included_txns = self.included_txns.clone();
+        included_txns.rotate();
+
+        let encoded_txns = &da_proposal.encoded_transactions;
+        let metadata = &da_proposal.metadata;
+
+        let block_payload =
+            <Types::BlockPayload as BlockPayload<Types>>::from_bytes(encoded_txns, metadata);
+        let txn_commitments = block_payload.transaction_commitments(metadata);
+
+        // We replace our parent_block_references with information from the
+        // quorum proposal.  This is identifying the block that this specific
+        // instance of [BuilderState] is attempting to build for.
+        let parent_block_references = ParentBlockReferences {
+            view_number: quorum_proposal.view_number,
+            vid_commitment: quorum_proposal.block_header.payload_commitment(),
+            leaf_commit: Committable::commit(&leaf),
+            builder_commitment: quorum_proposal.block_header.builder_commitment(),
+        };
+
+        let mut txn_queue = self.txn_queue.read().await.clone();
+        txn_queue.prune(txn_commitments.iter());
+
+        included_txns.extend(txn_commitments.into_iter());
+
+        Arc::new(BuilderState {
+            parent_block_references,
+            included_txns,
+            validated_state,
+            txn_queue: RwLock::new(txn_queue),
+            txn_receiver: Mutex::new(self.txn_receiver.lock().await.clone()),
+        })
+    }
+
+    // collect outstanding transactions
+    pub async fn collect_txns(&self, timeout_after: Instant) -> bool {
+        let mut queue_empty = self.txn_queue.read().await.is_empty();
+        while Instant::now() <= timeout_after {
+            let mut receiver_guard = self.txn_receiver.lock().await;
+            match receiver_guard.try_recv() {
+                Ok(txn) => {
+                    if self.included_txns.contains(&txn.commit) {
+                        // We've included this transaction in one of our
+                        // recent blocks, and we do not wish to include it
+                        // again.
+                        continue;
+                    }
+
+                    self.txn_queue.write().await.insert(txn);
+                    queue_empty = false;
+                }
+
+                Err(async_broadcast::TryRecvError::Empty)
+                | Err(async_broadcast::TryRecvError::Closed) => {
+                    // The transaction receiver is empty, or it's been closed.
+                    // If it's closed that's a big problem and we should
+                    // probably indicate it as such.
+                    break;
+                }
+
+                Err(async_broadcast::TryRecvError::Overflowed(lost)) => {
+                    tracing::warn!("Missed {lost} transactions due to backlog");
+                    continue;
+                }
+            }
+        }
+        queue_empty
+    }
+}

--- a/crates/shared/src/testing/constants.rs
+++ b/crates/shared/src/testing/constants.rs
@@ -11,6 +11,7 @@ pub const TEST_PROTOCOL_MAX_BLOCK_SIZE: u64 = 1_000_000;
 pub const TEST_MAX_BLOCK_SIZE_INCREMENT_PERIOD: Duration = Duration::from_secs(60);
 
 /// Controls the number of nodes that are used in the VID computation for the tests.
+/// This is an arbitrary default value for testing.
 pub const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
 
 /// Controls the number of attempts that the simulated consensus will
@@ -21,3 +22,7 @@ pub const TEST_NUM_CONSENSUS_RETRIES: usize = 4;
 /// All of the channels created need a capacity. The concrete capacity isn't
 /// specifically bounded in tests, so it is set to an arbitrary value.
 pub const TEST_CHANNEL_BUFFER_SIZE: usize = 32;
+
+/// Governs the included transaction GC period used in tests.
+/// This is an arbitrary default value for testing.
+pub const TEST_INCLUDED_TX_GC_PERIOD: Duration = Duration::from_secs(1);

--- a/crates/shared/src/testing/mock.rs
+++ b/crates/shared/src/testing/mock.rs
@@ -1,0 +1,147 @@
+use std::{marker::PhantomData, sync::Arc, time::Duration};
+
+use async_broadcast::broadcast;
+use committable::Commitment;
+use committable::Committable;
+use hotshot_example_types::block_types::{TestBlockHeader, TestBlockPayload, TestTransaction};
+use hotshot_example_types::{
+    node_types::{TestTypes, TestVersions},
+    state_types::{TestInstanceState, TestValidatedState},
+};
+use hotshot_types::data::ViewNumber;
+use hotshot_types::event::LeafInfo;
+use hotshot_types::traits::block_contents::{vid_commitment, GENESIS_VID_NUM_STORAGE_NODES};
+use hotshot_types::{
+    data::{random_commitment, DaProposal, Leaf, QuorumProposal},
+    message::UpgradeLock,
+    simple_certificate::QuorumCertificate,
+    simple_vote::{QuorumData, VersionedVoteData},
+    traits::node_implementation::{ConsensusTime, NodeType},
+    traits::BlockPayload,
+    utils::BuilderCommitment,
+    vid::vid_scheme,
+};
+use jf_vid::VidScheme;
+use rand::{distributions::Standard, thread_rng, Rng};
+
+use crate::block::ParentBlockReferences;
+use crate::state::BuilderState;
+
+use super::constants::{TEST_CHANNEL_BUFFER_SIZE, TEST_NUM_NODES_IN_VID_COMPUTATION};
+
+pub fn transaction() -> TestTransaction {
+    TestTransaction::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(100)
+            .collect::<Vec<_>>(),
+    )
+}
+
+pub async fn decide_leaf_chain(decided_view: u64) -> Arc<Vec<LeafInfo<TestTypes>>> {
+    let (_, quorum_proposal) = proposals(decided_view).await;
+    let leaf = Leaf::from_quorum_proposal(&quorum_proposal);
+    Arc::new(vec![LeafInfo {
+        leaf,
+        state: Default::default(),
+        delta: None,
+        vid_share: None,
+    }])
+}
+
+/// Create mock pair of DA and Quorum proposals
+pub async fn proposals(view: u64) -> (DaProposal<TestTypes>, QuorumProposal<TestTypes>) {
+    let view_number = <TestTypes as NodeType>::View::new(view);
+    let upgrade_lock = UpgradeLock::<TestTypes, TestVersions>::new();
+    let validated_state = TestValidatedState::default();
+    let instance_state = TestInstanceState::default();
+
+    let transaction = transaction();
+    let (payload, metadata) = <TestBlockPayload as BlockPayload<TestTypes>>::from_transactions(
+        vec![transaction.clone()],
+        &validated_state,
+        &instance_state,
+    )
+    .await
+    .unwrap();
+    let encoded_transactions = TestTransaction::encode(&[transaction]);
+
+    let header = TestBlockHeader::new(
+        &Leaf::<TestTypes>::genesis(&Default::default(), &Default::default()).await,
+        vid_commitment(&encoded_transactions, GENESIS_VID_NUM_STORAGE_NODES),
+        <TestBlockPayload as BlockPayload<TestTypes>>::builder_commitment(&payload, &metadata),
+        metadata,
+    );
+
+    let genesis_qc = QuorumCertificate::<TestTypes>::genesis::<TestVersions>(
+        &TestValidatedState::default(),
+        &TestInstanceState::default(),
+    )
+    .await;
+    let parent_proposal = QuorumProposal {
+        block_header: header,
+        view_number: ViewNumber::new(view_number.saturating_sub(1)),
+        justify_qc: genesis_qc,
+        upgrade_certificate: None,
+        proposal_certificate: None,
+    };
+    let leaf = Leaf::from_quorum_proposal(&parent_proposal);
+
+    let quorum_data = QuorumData {
+        leaf_commit: leaf.commit(&upgrade_lock).await,
+    };
+
+    let versioned_data = VersionedVoteData::<_, _, _>::new_infallible(
+        quorum_data.clone(),
+        view_number,
+        &upgrade_lock,
+    )
+    .await;
+
+    let commitment = Commitment::from_raw(versioned_data.commit().into());
+
+    let justify_qc =
+        QuorumCertificate::new(quorum_data, commitment, view_number, None, PhantomData);
+
+    (
+        DaProposal {
+            encoded_transactions: encoded_transactions.into(),
+            metadata,
+            view_number,
+        },
+        QuorumProposal {
+            block_header: leaf.block_header().clone(),
+            view_number,
+            justify_qc,
+            upgrade_certificate: None,
+            proposal_certificate: None,
+        },
+    )
+}
+
+pub fn builder_state(view: u64) -> Arc<BuilderState<TestTypes>> {
+    let references = parent_references(view);
+    let (_, receiver) = broadcast(TEST_CHANNEL_BUFFER_SIZE);
+    BuilderState::new(
+        references,
+        Duration::from_secs(1),
+        receiver,
+        TestValidatedState::default(),
+    )
+}
+
+/// Generate references for given view number with random
+/// commitments for use in testing code
+pub fn parent_references(view: u64) -> ParentBlockReferences<TestTypes> {
+    let rng = &mut thread_rng();
+    ParentBlockReferences {
+        view_number: <TestTypes as NodeType>::View::new(view),
+        leaf_commit: random_commitment(rng),
+        vid_commitment: vid_scheme(TEST_NUM_NODES_IN_VID_COMPUTATION)
+            .commit_only(rng.sample_iter(Standard).take(100).collect::<Vec<_>>())
+            .unwrap(),
+        builder_commitment: BuilderCommitment::from_bytes(
+            rng.sample_iter(Standard).take(32).collect::<Vec<_>>(),
+        ),
+    }
+}

--- a/crates/shared/src/testing/mod.rs
+++ b/crates/shared/src/testing/mod.rs
@@ -13,6 +13,7 @@ use validation::BuilderValidationConfig;
 
 pub mod constants;
 pub mod generation;
+pub mod mock;
 pub mod validation;
 
 /// Transaction payload used in testing to track various properties


### PR DESCRIPTION
Closes #241

### This PR:
This is a preparatory PR to the refactor, doesn't yet change any of the marketplace & legacy code.
- Implements generic `BuilderStateCoordinator`
- Implements generic `BuilderState`

For a mostly finished example of how coordinator's supposed to be used, see #238 

### This PR does not:
Change anything outside shared crate

### Key places to review:
Everything, the best place to start would probably be `crates/shared/src/coordinator/mod.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
