### PR TITLE
Fix the events service connection

### DIFF
--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -296,7 +296,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn event_stream_wrapper() {
+    async fn test_event_stream_wrapper() {
         const TIMEOUT: Duration = Duration::from_secs(3);
 
         let url: Url = format!(
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn event_stream_wrapper_with_idle_timeout() {
+    async fn test_event_stream_wrapper_with_idle_timeout() {
         const TIMEOUT: Duration = Duration::from_secs(3);
 
         let url: Url = format!(

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -229,6 +229,7 @@ mod tests {
     use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
     use tide_disco::{method::ReadState, App};
     use tokio::{spawn, task::JoinHandle, time::timeout};
+    use tracing::debug;
     use url::Url;
     use vbs::version::StaticVersion;
 
@@ -371,9 +372,9 @@ mod tests {
         )
         .await
         {
-            Ok(Some(_)) => println!("Expected error after idle timeout but got an event"),
+            Ok(Some(_)) => panic!("Expected error after idle timeout but got an event"),
             Ok(None) => panic!("Expected error but got None"),
-            Err(err) => panic!("Stream returned an error after idle timeout: {:?}", err),
+            Err(err) => debug!("Stream returned an error after idle timeout: {:?}", err),
         }
 
         // Stream should reconnect after idle timeout

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -229,6 +229,7 @@ mod tests {
     use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
     use tide_disco::{method::ReadState, App};
     use tokio::{spawn, task::JoinHandle, time::timeout};
+    use tracing::debug;
     use url::Url;
     use vbs::version::StaticVersion;
 
@@ -371,9 +372,9 @@ mod tests {
         )
         .await
         {
-            Ok(Some(_)) => panic!("Expected error after idle timeout but got an event"),
+            Ok(Some(_)) => println!("Expected error after idle timeout but got an event"),
             Ok(None) => panic!("Expected error but got None"),
-            Err(err) => println!("Stream returned an error after idle timeout: {:?}", err),
+            Err(err) => panic!("Stream returned an error after idle timeout: {:?}", err),
         }
 
         // Stream should reconnect after idle timeout

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -353,7 +353,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Test: The stream should work when the server is running
+        // The stream should work when the server is running
         timeout(TIMEOUT, stream.next())
             .await
             .expect("When mock event server is spawned, stream should work")
@@ -363,7 +363,7 @@ mod tests {
         app_handle.abort();
         tokio::time::sleep(IDLE_TIMEOUT + Duration::from_millis(500)).await; // Wait longer than idle timeout
 
-        // Test: Stream should reconnect after idle timeout
+        // Stream should reconnect after idle timeout
         let new_app_handle = run_app("hotshot-events", url.clone());
 
         timeout(TIMEOUT, stream.next())

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -195,7 +195,7 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
                     },
                 }
 
-                // Disconnect and reconnect if no event has been received within 1 second
+                // Disconnect and reconnect if no event has been received within quite a long time (set to 1s by default)
                 if Instant::now().duration_since(this.last_event_time) > Self::RETRY_PERIOD {
                     warn!("No events received for quite a long time, reconnecting");
                     let fut = Self::connect_inner(this.api_url.clone());

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -344,45 +344,45 @@ mod tests {
             .expect_err("API is reachable, but is on wrong path");
     }
 
-    // #[tokio::test(flavor = "multi_thread")]
-    // async fn event_stream_wrapper_with_idle_timeout() {
-    //     const TIMEOUT: Duration = Duration::from_secs(3);
-    //     const IDLE_TIMEOUT: Duration = Duration::from_secs(1);
+    #[tokio::test(flavor = "multi_thread")]
+    async fn event_stream_wrapper_with_idle_timeout() {
+        const TIMEOUT: Duration = Duration::from_secs(3);
+        const IDLE_TIMEOUT: Duration = Duration::from_secs(1);
 
-    //     let url: Url = format!(
-    //         "http://localhost:{}",
-    //         portpicker::pick_unused_port().unwrap()
-    //     )
-    //     .parse()
-    //     .unwrap();
+        let url: Url = format!(
+            "http://localhost:{}",
+            portpicker::pick_unused_port().unwrap()
+        )
+        .parse()
+        .unwrap();
 
-    //     let app_handle = run_app("hotshot-events", url.clone());
+        let app_handle = run_app("hotshot-events", url.clone());
 
-    //     let mut stream = EventServiceStream::<TestTypes, MockVersion>::connect(url.clone())
-    //         .await
-    //         .unwrap();
+        let mut stream = EventServiceStream::<TestTypes, MockVersion>::connect(url.clone())
+            .await
+            .unwrap();
 
-    //     // The stream should work when the server is running
-    //     timeout(TIMEOUT, stream.next())
-    //         .await
-    //         .expect("When mock event server is spawned, stream should work")
-    //         .unwrap();
+        // The stream should work when the server is running
+        timeout(TIMEOUT, stream.next())
+            .await
+            .expect("When mock event server is spawned, stream should work")
+            .unwrap();
 
-    //     // Simulate idle timeout by stopping the server and waiting
-    //     app_handle.abort();
-    //     tokio::time::sleep(IDLE_TIMEOUT + Duration::from_millis(500)).await; // Wait longer than idle timeout
+        // Simulate idle timeout by stopping the server and waiting
+        app_handle.abort();
+        tokio::time::sleep(IDLE_TIMEOUT + Duration::from_millis(500)).await; // Wait longer than idle timeout
 
-    //     // Stream should reconnect after idle timeout
-    //     let new_app_handle = run_app("hotshot-events", url.clone());
+        // Stream should reconnect after idle timeout
+        let new_app_handle = run_app("hotshot-events", url.clone());
 
-    //     timeout(TIMEOUT, stream.next())
-    //         .await
-    //         .expect("After idle timeout, stream should reconnect when the server restarts")
-    //         .unwrap();
+        timeout(TIMEOUT, stream.next())
+            .await
+            .expect("After idle timeout, stream should reconnect when the server restarts")
+            .unwrap();
 
-    //     // Cleanup
-    //     new_app_handle.abort();
-    // }
+        // Cleanup
+        new_app_handle.abort();
+    }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -229,7 +229,6 @@ mod tests {
     use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
     use tide_disco::{method::ReadState, App};
     use tokio::{spawn, task::JoinHandle, time::timeout};
-    use tracing::debug;
     use url::Url;
     use vbs::version::StaticVersion;
 

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -168,17 +168,14 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
                             Ok(Some(Ok(event))) => {
                                 // Update the last_event_time on receiving an event
                                 this.last_event_time = Instant::now();
-                                tracing::error!("enter Ok(Some(Ok(event)))");
                                 return Some((event, this));
                             }
                             Ok(Some(Err(err))) => {
                                 warn!(?err, "Error in event stream");
-                                tracing::error!("enter Ok(Some(Err(err)))");
                                 continue;
                             }
                             Ok(None) => {
                                 warn!("Event stream ended, attempting reconnection");
-                                tracing::error!("enter Ok(None)");
                                 let fut = Self::connect_inner(this.api_url.clone());
                                 let _ =
                                     std::mem::replace(&mut this.connection, Right(Box::pin(fut)));
@@ -187,9 +184,9 @@ impl<Types: NodeType, ApiVer: StaticVersionType + 'static> EventServiceStream<Ty
                             Err(_) => {
                                 // Timeout occurred, reconnect
                                 warn!("Timeout waiting for next event; reconnecting");
-                                tracing::error!("enter Err(_)");
                                 let fut = Self::connect_inner(this.api_url.clone());
-                                let _ = std::mem::replace(&mut this.connection, Right(Box::pin(fut)));
+                                let _ =
+                                    std::mem::replace(&mut this.connection, Right(Box::pin(fut)));
                                 continue;
                             }
                         }
@@ -301,7 +298,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn event_stream_wrapper() {
-
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .try_init();

--- a/crates/shared/src/utils.rs
+++ b/crates/shared/src/utils.rs
@@ -364,6 +364,17 @@ mod tests {
             EventServiceStream::<TestTypes, MockVersion>::RETRY_PERIOD + Duration::from_millis(500),
         )
         .await; // Wait longer than idle timeout
+                // Check whether stream returns Err(_) after idle timeout
+        match timeout(
+            EventServiceStream::<TestTypes, MockVersion>::RETRY_PERIOD,
+            stream.next(),
+        )
+        .await
+        {
+            Ok(Some(_)) => panic!("Expected error after idle timeout but got an event"),
+            Ok(None) => panic!("Expected error but got None"),
+            Err(err) => println!("Stream returned an error after idle timeout: {:?}", err),
+        }
 
         // Stream should reconnect after idle timeout
         let new_app_handle = run_app("hotshot-events", url.clone());


### PR DESCRIPTION
Closes #255 
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

Pasted here what @Ayiga mentioned regarding the connection issue:
- I noticed during the running of the inscriptions service, after Mainnet went through it’s degraded behavior and recovered, that the Block stream never recovered.
    - There’s already code in both the Builder and in the Inscriptions service to automatically reconnect when we detect that the stream is “closed”.  There may be some underlying issue with the source rather than the consumer.
    - We may still want to address this on the consumer side, however, and the best way to address that, I think, is to keep track of the time since the last object received.
    - Since both the Block Stream, and the Event Stream should be receiving events fairly often, it seems like a good safe guard to determine whether we are in a state that doesn’t seem to be progressing.
    - Once this state is detected, we can just trigger a reconnect in hopes that it will recover and resolve the issue.
    
    > NOTE: With this approach, we may end up triggering (at least with the block stream) unnecessarily due to potential latency / timeouts in the consensus protocol itself.

### This PR:
- Adds a time period check for disconnecting and reconnecting when no events are received for too long ( now set to 1 second).
- Introduces a timestamp to track the last received event time in EventServiceStream.
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
